### PR TITLE
Dashboard close behaviour and labels layout updated.

### DIFF
--- a/custom_pvpn_cli_ng/protonvpn_cli/connection.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/connection.py
@@ -139,7 +139,7 @@ def random_c(protocol=None):
     openvpn_connect(servername, protocol)
 
 
-def fastest(protocol=None, gui_enabled=False, return_dict=False):
+def fastest(protocol=None, gui_enabled=False):
     """Connect to the fastest server available."""
 
     logger.debug("Starting fastest connect")
@@ -163,7 +163,7 @@ def fastest(protocol=None, gui_enabled=False, return_dict=False):
 
     fastest_server = get_fastest_server(server_pool)
     if gui_enabled:
-        return openvpn_connect(fastest_server, protocol, gui_enabled, return_dict)
+        return openvpn_connect(fastest_server, protocol, gui_enabled)
     openvpn_connect(fastest_server, protocol)
 
 
@@ -439,7 +439,7 @@ def status(gui_enabled=False):
     )
 
 
-def openvpn_connect(servername, protocol, gui_enabled=False, return_dict=False ):
+def openvpn_connect(servername, protocol, gui_enabled=False):
     """Connect to VPN Server."""
 
     logger.debug("Initiating OpenVPN connection")
@@ -467,7 +467,7 @@ def openvpn_connect(servername, protocol, gui_enabled=False, return_dict=False )
 
     old_ip, _ = get_ip_info()
 
-    # print("Connecting to {0} via {1}...".format(servername, protocol.upper()))
+    print("Connecting to {0} via {1}...".format(servername, protocol.upper()))
 
     with open(os.path.join(CONFIG_DIR, "ovpn.log"), "w+") as f:
         subprocess.Popen(
@@ -514,9 +514,6 @@ def openvpn_connect(servername, protocol, gui_enabled=False, return_dict=False )
                     logger.debug("Failed to connect. IP didn't change")
                     print("[!] Connection failed. Reverting all changes...")
                     disconnect(passed=True)
-                if gui_enabled == True:
-                    return_dict.put({"CONNECTION":"CONNECTED WITH PROCESS"})
-                    sys.exit(1)
                 print("Connected!")
                 logger.debug("Connection successful")
                 break
@@ -529,15 +526,10 @@ def openvpn_connect(servername, protocol, gui_enabled=False, return_dict=False )
                 )
                 logger.debug("Authentication failure")
                 if not gui_enabled == True:
-                    return_dict.put({"CONNECTION":"Failed to authenticate"})
                     sys.exit(1)
-                return "UNABLE TO CONNECT WITH PROCESS"
-                # break
+                break
             # Stop after 45s
             elif time.time() - time_start >= 45:
-                if gui_enabled == True:
-                    return_dict.put({"CONNECTION":"TIMED OUT, PROCESS"})
-                    sys.exit(1)
                 print("Connection timed out after 45 Seconds")
                 logger.debug("Connection timed out after 45 Seconds")
                 sys.exit(1)

--- a/custom_pvpn_cli_ng/protonvpn_cli/connection.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/connection.py
@@ -348,7 +348,7 @@ def disconnect(passed=False):
         logger.debug("No connection found")
 
 
-def status():
+def status(gui_enabled=False):
     """
     Display the current VPN status
 

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.1.5"
+VERSION = "1.2.0"
 PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/protonvpn-autoconnect.service"
 TEMPLATE ="""
 [Unit]

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -143,9 +143,11 @@ class Handler:
         
     def refresh_server_list_button_clicked(self, button):
         """Button/Event handler to refresh/repopulate server list
+        - At the moment, will also refresh the Dashboard information, this will be fixed in the future.
         """
         server_list_object = self.interface.get_object("ServerListStore")
         populate_server_list(server_list_object)
+        update_labels_status(self.interface)
 
     def about_menu_button_clicked(self, button):
         """Button /Event handlerto open About dialog

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -3,7 +3,6 @@ import os
 import re
 import sys
 import pathlib
-from multiprocessing import Process, Queue, Manager, Pool
 from threading import Thread
 import time
 
@@ -120,21 +119,7 @@ class Handler:
         """Button/Event handler to connect to the fastest server
         """
         protocol = get_config_value("USER", "default_protocol")
-        protocol = get_config_value("USER", "default_protocol")
         connection.fastest(protocol, gui_enabled=True)
-        # return_val = Queue()
-        # p = Process(target=connection.fastest, args=(protocol, gui_enabled, return_val))
-        # p = Thread(target=connection.fastest, args=(protocol, gui_enabled, return_val))
-        # p.start()
-        # print(return_val.get())
-        # p.join()
-        # connection.fastest(protocol, gui_enabled=True)
-        # p.join()
-        # pool = Pool()
-        # pool.apply_async(connection.fastest, args=(protocol, gui_enabled), callback = self.log_result)
-        # pool.close()
-        # pool.join()
-        # print(pool.get())
         update_labels_status(self.interface)
     
     def last_connect_button_clicked(self, button):
@@ -340,6 +325,7 @@ class initialize_gui:
     """
     def __init__(self):
         check_root()
+
         interface = Gtk.Builder()
 
         posixPath = pathlib.PurePath(pathlib.Path(__file__).parent.absolute().joinpath("resources/main.glade"))

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -304,24 +304,16 @@ class Handler:
         cli.purge_configuration(gui_enabled=True)
 
 class initialize_gui:
-    """Initializes a GUI
-    -----
-    The GUI only makes external calls to the cli commands.
-    -----
-    Will request for the same data protonvpn init to initialize a user:
-    -Username
-    -Password
-    -Plan
-    -Protocol
-
-    There are two ways of starting this GUI, either by reversing the commented code so that it can be launched as part of the CLI: 
+    """Initializes the GUI 
     ---
-    -protonvpn gui:
-        This will start from within the main CLI menu. Gui is invoked through cli()
+    If user has not initialized a profile, the GUI will ask for the following data:
+    - Username
+    - Password
+    - Plan
+    - Protocol
 
-    Or leave it be as it is, and configuration is setup during installation with "pip3 install -e .", this way it can be launched as a separte command from the usual CLI:
-    -protonvpn-gui:
-        This will start the GUI without invoking cli()
+    sudo protonvpn-gui
+    - Will start the GUI without invoking cli()
     """
     def __init__(self):
         check_root()

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -3,6 +3,9 @@ import os
 import re
 import sys
 import pathlib
+from multiprocessing import Process, Queue, Manager, Pool
+from threading import Thread
+import time
 
 # ProtonVPN base CLI package import
 from custom_pvpn_cli_ng.protonvpn_cli.constants import (USER, CONFIG_FILE, CONFIG_DIR, VERSION)
@@ -110,11 +113,28 @@ class Handler:
         connection.openvpn_connect(selected_server, protocol)
         update_labels_status(self.interface)
         
+    # def log_result(self, res):
+    #     return res
+
     def quick_connect_button_clicked(self, button):
         """Button/Event handler to connect to the fastest server
         """
         protocol = get_config_value("USER", "default_protocol")
+        protocol = get_config_value("USER", "default_protocol")
         connection.fastest(protocol, gui_enabled=True)
+        # return_val = Queue()
+        # p = Process(target=connection.fastest, args=(protocol, gui_enabled, return_val))
+        # p = Thread(target=connection.fastest, args=(protocol, gui_enabled, return_val))
+        # p.start()
+        # print(return_val.get())
+        # p.join()
+        # connection.fastest(protocol, gui_enabled=True)
+        # p.join()
+        # pool = Pool()
+        # pool.apply_async(connection.fastest, args=(protocol, gui_enabled), callback = self.log_result)
+        # pool.close()
+        # pool.join()
+        # print(pool.get())
         update_labels_status(self.interface)
     
     def last_connect_button_clicked(self, button):
@@ -338,6 +358,7 @@ class initialize_gui:
             window = interface.get_object("LoginWindow")
         else:
             window = interface.get_object("Dashboard")
+            window.connect("destroy", Gtk.main_quit)
             load_on_start(interface)
 
         window.show()

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1618,7 +1618,6 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1387,157 +1387,519 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">center</property>
+            <property name="halign">center</property>
             <property name="margin_left">60</property>
             <property name="margin_right">60</property>
             <property name="margin_bottom">20</property>
-            <property name="row_spacing">5</property>
+            <property name="hexpand">True</property>
+            <property name="column_spacing">150</property>
+            <property name="row_homogeneous">True</property>
             <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
+              <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">False</property>
-                <property name="label" translatable="yes">VPN Status: </property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
+                <property name="column_spacing">20</property>
+                <property name="row_homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Time connected:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="time_connected_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">False</property>
+                    <property name="label" translatable="yes">VPN Status:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="vpn_status_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Running</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">DNS Protection:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="dns_status_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Custom</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Killswitch Setting:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Protocol:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Features:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="killswitch_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="openvpn_protocol_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_features_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Custom</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
+                <property name="width">2</property>
+                <property name="height">10</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
+              <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">DNS Protection: </property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="vpn_status_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Running</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="ultrabold"/>
-                  <attribute name="underline" value="True"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="dns_status_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Custom</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="ultrabold"/>
-                  <attribute name="underline" value="True"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="margin_left">40</property>
-                <property name="label" translatable="yes">IP: </property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
+                <property name="margin_left">100</property>
+                <property name="column_spacing">20</property>
+                <property name="row_homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel" id="ip_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Country: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="country_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">City:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Server:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Load:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Received: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Sent: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">IP: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_load_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_name_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_city_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="data_received_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="data_sent_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">2</property>
                 <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="margin_left">40</property>
-                <property name="label" translatable="yes">Country: </property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="country_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="ip_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">0</property>
+                <property name="width">4</property>
+                <property name="height">10</property>
               </packing>
             </child>
           </object>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1358,7 +1358,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
             <property name="margin_left">80</property>
             <property name="margin_right">80</property>
             <property name="margin_top">15</property>
-            <property name="margin_bottom">35</property>
+            <property name="margin_bottom">15</property>
             <property name="column_homogeneous">True</property>
             <property name="baseline_row">1</property>
             <child>
@@ -1390,14 +1390,14 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
             <property name="halign">center</property>
             <property name="margin_left">60</property>
             <property name="margin_right">60</property>
-            <property name="margin_bottom">20</property>
             <property name="hexpand">True</property>
             <property name="column_spacing">150</property>
             <property name="row_homogeneous">True</property>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkGrid" id="left_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">30</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>
@@ -1411,7 +1411,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1430,7 +1430,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1449,7 +1449,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1469,7 +1469,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1488,7 +1488,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1508,7 +1508,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1527,7 +1527,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1546,7 +1546,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1565,7 +1565,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1584,7 +1584,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1603,7 +1603,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1622,7 +1622,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1639,7 +1639,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
               </packing>
             </child>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkGrid" id="right_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">100</property>
@@ -1654,7 +1654,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1671,7 +1671,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Country: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1688,7 +1688,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1705,7 +1705,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">City:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1722,7 +1722,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Server:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1739,7 +1739,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Load:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1756,7 +1756,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Received: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1773,7 +1773,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Sent: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1790,7 +1790,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">IP: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1809,7 +1809,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1828,7 +1828,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1847,7 +1847,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1866,7 +1866,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1885,7 +1885,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1910,6 +1910,8 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
         </child>
         <child>
           <object class="GtkGrid">
+            <property name="width_request">-1</property>
+            <property name="height_request">4</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_left">30</property>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1428,8 +1428,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1467,8 +1466,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Running</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1506,8 +1504,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1582,8 +1579,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1601,8 +1597,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1620,8 +1615,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1807,8 +1801,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1826,8 +1819,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1845,8 +1837,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1864,8 +1855,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1883,8 +1873,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1358,7 +1358,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
             <property name="margin_left">80</property>
             <property name="margin_right">80</property>
             <property name="margin_top">15</property>
-            <property name="margin_bottom">35</property>
+            <property name="margin_bottom">15</property>
             <property name="column_homogeneous">True</property>
             <property name="baseline_row">1</property>
             <child>
@@ -1390,7 +1390,6 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
             <property name="halign">center</property>
             <property name="margin_left">60</property>
             <property name="margin_right">60</property>
-            <property name="margin_bottom">20</property>
             <property name="hexpand">True</property>
             <property name="column_spacing">150</property>
             <property name="row_homogeneous">True</property>
@@ -1429,8 +1428,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1468,8 +1466,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Running</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1507,8 +1504,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1583,7 +1579,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="underline" value="True"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
@@ -1602,7 +1598,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="underline" value="True"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
@@ -1621,7 +1617,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="underline" value="True"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
@@ -1808,8 +1804,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1827,8 +1822,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1846,8 +1840,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1865,8 +1858,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1884,8 +1876,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <property name="justify">fill</property>
                     <attributes>
-                      <attribute name="weight" value="ultrabold"/>
-                      <attribute name="underline" value="True"/>
+                      <attribute name="weight" value="bold"/>
                       <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
@@ -1911,6 +1902,8 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
         </child>
         <child>
           <object class="GtkGrid">
+            <property name="width_request">-1</property>
+            <property name="height_request">4</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_left">30</property>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1395,9 +1395,10 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
             <property name="column_spacing">150</property>
             <property name="row_homogeneous">True</property>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkGrid" id="left_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_left">30</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>
@@ -1411,7 +1412,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1430,7 +1431,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1449,7 +1450,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1469,7 +1470,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1488,7 +1489,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1508,7 +1509,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1527,7 +1528,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1546,7 +1547,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1565,7 +1566,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1584,7 +1585,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1603,7 +1604,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1618,12 +1619,11 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1640,7 +1640,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
               </packing>
             </child>
             <child>
-              <object class="GtkGrid">
+              <object class="GtkGrid" id="right_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">100</property>
@@ -1655,7 +1655,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1672,7 +1672,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Country: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1689,7 +1689,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="hexpand">True</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1706,7 +1706,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">City:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1723,7 +1723,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Server:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1740,7 +1740,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Load:</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1757,7 +1757,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Received: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1774,7 +1774,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">Sent: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1791,7 +1791,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <property name="label" translatable="yes">IP: </property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1810,7 +1810,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1829,7 +1829,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1848,7 +1848,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1867,7 +1867,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>
@@ -1886,7 +1886,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                     <attributes>
                       <attribute name="weight" value="ultrabold"/>
                       <attribute name="underline" value="True"/>
-                      <attribute name="size" value="20000"/>
+                      <attribute name="size" value="15000"/>
                     </attributes>
                   </object>
                   <packing>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1375,38 +1375,6 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                 <property name="width">4</property>
               </packing>
             </child>
-            <child>
-              <object class="GtkButton" id="start_on_boot_button">
-                <property name="label" translatable="yes">Start on Boot</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="start_on_boot_button_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="disable_on_boot_button">
-                <property name="label" translatable="yes">Disable start on boot</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <signal name="clicked" handler="disable_on_boot_button_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -1419,157 +1387,519 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="valign">center</property>
+            <property name="halign">center</property>
             <property name="margin_left">60</property>
             <property name="margin_right">60</property>
             <property name="margin_bottom">20</property>
-            <property name="row_spacing">5</property>
+            <property name="hexpand">True</property>
+            <property name="column_spacing">150</property>
+            <property name="row_homogeneous">True</property>
             <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
+              <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">False</property>
-                <property name="label" translatable="yes">VPN Status: </property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
+                <property name="column_spacing">20</property>
+                <property name="row_homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Time connected:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="time_connected_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">False</property>
+                    <property name="label" translatable="yes">VPN Status:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="vpn_status_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Running</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">DNS Protection:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="dns_status_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Custom</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Killswitch Setting:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Protocol:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Features:</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="killswitch_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="openvpn_protocol_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_features_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">Custom</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
+                <property name="width">2</property>
+                <property name="height">10</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
+              <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">DNS Protection: </property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="vpn_status_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Running</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="ultrabold"/>
-                  <attribute name="underline" value="True"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="dns_status_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <property name="label" translatable="yes">Custom</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="ultrabold"/>
-                  <attribute name="underline" value="True"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="margin_left">40</property>
-                <property name="label" translatable="yes">IP: </property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
+                <property name="margin_left">100</property>
+                <property name="column_spacing">20</property>
+                <property name="row_homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel" id="ip_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Country: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="country_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">City:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Server:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Load:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Received: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Sent: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">IP: </property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_load_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_name_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="server_city_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="data_received_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="data_sent_label">
+                    <property name="width_request">-1</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="justify">fill</property>
+                    <attributes>
+                      <attribute name="weight" value="ultrabold"/>
+                      <attribute name="underline" value="True"/>
+                      <attribute name="size" value="20000"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">6</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">2</property>
                 <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="margin_left">40</property>
-                <property name="label" translatable="yes">Country: </property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="country_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel" id="ip_label">
-                <property name="width_request">-1</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="hexpand">True</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="20000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">0</property>
+                <property name="width">4</property>
+                <property name="height">10</property>
               </packing>
             </child>
           </object>

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -85,7 +85,9 @@ def left_grid_update_labels(interface):
     protocol_label =        interface.get_object("openvpn_protocol_label")
     server_features_label = interface.get_object("server_features_label")
 
-    # Check and set VPN status. Get also protocol if connected
+    all_features = {0: "Normal", 1: "Secure-Core", 2: "Tor", 4: "P2P"}
+
+    # Check and set VPN status label. Get also protocol status if vpn is connected
     if is_connected() != True:
         vpn_status_label.set_markup('<span>Disconnected</span>')
     else:
@@ -94,21 +96,41 @@ def left_grid_update_labels(interface):
             connected_time = get_config_value("metadata", "connected_time")
             connection_time = time.time() - int(connected_time)
             connection_time = str(datetime.timedelta(seconds=connection_time)).split(".")[0]
+            connected_to_protocol = get_config_value("metadata", "connected_proto")
+            connected_server = get_config_value("metadata", "connected_server")
         except KeyError:
             connection_time = False
+            connected_to_protocol = False
+            connected_server = False
     
-    # Check and set DNS status
+    # Check and set DNS status label
     dns_enabled = get_config_value("USER", "dns_leak_protection")
     if int(dns_enabled) != 1:
         dns_status_label.set_markup('<span>Not Enabled</span>')
     else:
         dns_status_label.set_markup('<span foreground="#4E9A06">Enabled</span>')
 
-    # Set time connected
+    # Set time connected label
     connection_time = connection_time if connection_time else ""
     time_connected_label.set_markup('<span>{0}</span>'.format(connection_time))
 
+    # Check and set killswitch label
+    connected_time = get_config_value("USER", "killswitch")
+    killswitch_status = "Enabled" if connected_time == 0 else "Disabled"
+    killswitch_label.set_markup('<span>{0}</span>'.format(killswitch_status))
 
+    # Check and set protocol label
+    connected_to_protocol = connected_to_protocol if connected_to_protocol else ""
+    protocol_label.set_markup('<span>{0}</span>'.format(connected_to_protocol))
+
+    # Check and set features label
+    servers = get_servers()
+    try:
+        feature = get_server_value(connected_server, "Features", servers)
+    except KeyError:
+        feature = False
+    feature = all_features[feature] if feature else ""
+    server_features_label.set_markup('<span>{0}</span>'.format(feature))
 
 def right_grid_update_labels(interface):
     # Right grid
@@ -126,7 +148,7 @@ def right_grid_update_labels(interface):
     if is_connected():
         try:
             connected_to_server = get_config_value("metadata", "connected_server")
-            connected_to_protocol = get_config_value("metadata", "connected_proto")
+            
         except KeyError:
             pass 
 

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -14,8 +14,9 @@ from custom_pvpn_cli_ng.protonvpn_cli.utils import (
     check_root,
     is_connected,
     get_ip_info,
-    status
 )
+
+from custom_pvpn_cli_ng.protonvpn_cli.connection import status
 
 from custom_pvpn_cli_ng.protonvpn_cli.constants import SPLIT_TUNNEL_FILE
 

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -13,7 +13,8 @@ from custom_pvpn_cli_ng.protonvpn_cli.utils import (
     set_config_value,
     check_root,
     is_connected,
-    get_ip_info
+    get_ip_info,
+    status
 )
 
 from custom_pvpn_cli_ng.protonvpn_cli.constants import SPLIT_TUNNEL_FILE
@@ -73,12 +74,14 @@ def update_labels_status(interface):
     ip_label = interface.get_object("ip_label")
     country_label = interface.get_object("country_label")
 
+    # Under development
+    # vpn_status = status(gui_enabled=True)    
 
     # Check VPN status
     if is_connected() != True:
-        vpn_status_label.set_markup('<span>Not Running</span>')
+        vpn_status_label.set_markup('<span>Disconnected</span>')
     else:
-        vpn_status_label.set_markup('<span foreground="#4E9A06">Running</span>')
+        vpn_status_label.set_markup('<span foreground="#4E9A06">Connected</span>')
     
     # Check DNS status
     dns_enabled = get_config_value("USER", "dns_leak_protection")

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -70,10 +70,23 @@ def load_on_start(interface):
 def update_labels_status(interface):
     """Updates labels status
     """
-    vpn_status_label = interface.get_object("vpn_status_label")
-    dns_status_label = interface.get_object("dns_status_label")
-    ip_label = interface.get_object("ip_label")
-    country_label = interface.get_object("country_label")
+    
+    # Left grid
+    vpn_status_label =      interface.get_object("vpn_status_label")
+    dns_status_label =      interface.get_object("dns_status_label")
+    time_connected_label =  interface.get_object("time_connected_label")
+    killswitch_label =      interface.get_object("killswitch_label")
+    protocol_label =        interface.get_object("openvpn_protocol_label")
+    server_features_label = interface.get_object("server_features_label")
+
+    # Right grid
+    ip_label =              interface.get_object("ip_label")
+    server_load_label =     interface.get_object("server_load_label")
+    server_name_label =     interface.get_object("server_name_label")
+    server_city_label =     interface.get_object("server_city_label")
+    country_label =         interface.get_object("country_label")
+    data_received_label =   interface.get_object("data_received_label")
+    data_sent_label =       interface.get_object("data_sent_label")
 
     # Under development
     # vpn_status = status(gui_enabled=True)    
@@ -98,6 +111,8 @@ def update_labels_status(interface):
 
     ip_label.set_markup(ip)
     country_label.set_markup(country_isp)
+
+
 
 def load_configurations(interface):
     """Set and populate user configurations before showing the configurations window


### PR DESCRIPTION
**Functionality:**
- Dashboard will now elegantly close when a user presses on the X button at the top. Previously, the terminal would still be hanging. This unwanted behavior has not been fixed.  

**Layout:**
- Added several new labels, that give a more detailed information about the connection, such as:
  - How long a user is connected to the server
  - Actual OpenVPN protocol in use
  - Features that the server offers (during the actual connection)
  - Server load
  - Server name
  - City
  - The ammount of data received
  - The ammount of data sent

**NOTE:**
Since at the moment there is no threading or asynch behaviors, to update Dashboard information, the user just needs to click on the _Refresh_ button. This will automatically update, both the server list as well as the labels.
 