### PR TITLE
Several issue fixes and diagnosis tool added

### DIFF
--- a/custom_pvpn_cli_ng/protonvpn_cli/connection.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/connection.py
@@ -572,8 +572,9 @@ def openvpn_connect(servername, protocol, gui_enabled=False):
     with open(CONFIG_FILE, "w+") as f:
         config.write(f)
 
-    check_update()
-    return return_message
+    # check_update()
+    if gui_enabled:
+        return return_message
 
 
 def manage_dns(mode, dns_server=False):

--- a/custom_pvpn_cli_ng/protonvpn_cli/utils.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/utils.py
@@ -98,10 +98,21 @@ def pull_server_data(force=False):
 def get_servers():
     """Return a list of all servers for the users Tier."""
 
-    with open(SERVER_INFO_FILE, "r") as f:
-        logger.debug("Reading servers from file")
-        server_data = json.load(f)
+    server_data = {}
 
+    while True:
+        with open(SERVER_INFO_FILE, "r") as f:
+            logger.debug("Reading servers from file")
+            try:
+                data = json.load(f)
+                if not data == None and not len(data) == 0:
+                    server_data = data
+                    break
+            except:
+                pull_server_data(force=True)
+                time.sleep(2)
+                pass
+    
     servers = server_data["LogicalServers"]
 
     user_tier = int(get_config_value("USER", "tier"))

--- a/custom_pvpn_cli_ng/protonvpn_cli/utils.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/utils.py
@@ -21,7 +21,7 @@ from .constants import (
 )
 
 
-def call_api(endpoint, json_format=True, handle_errors=True):
+def call_api(endpoint, json_format=True, handle_errors=True, gui_enabled=False):
     """Call to the ProtonVPN API."""
 
     api_domain = "https://api.protonvpn.ch"
@@ -44,10 +44,11 @@ def call_api(endpoint, json_format=True, handle_errors=True):
         response = requests.get(url, headers=headers)
     except (requests.exceptions.ConnectionError,
             requests.exceptions.ConnectTimeout):
-        print(
-            "[!] There was an error connecting to the ProtonVPN API.\n"
-            "[!] Please make sure your connection is working properly!"
-        )
+        if not gui_enabled:
+            print(
+                "[!] There was an error connecting to the ProtonVPN API.\n"
+                "[!] Please make sure your connection is working properly!"
+            )
         logger.debug("Error connecting to ProtonVPN API")
         return
         # sys.exit(1)
@@ -99,8 +100,12 @@ def get_servers():
     """Return a list of all servers for the users Tier."""
 
     server_data = {}
+    timer_start = time.time()
 
     while True:
+        if time.time() - timer_start > 5:
+            break
+
         with open(SERVER_INFO_FILE, "r") as f:
             logger.debug("Reading servers from file")
             try:
@@ -112,7 +117,12 @@ def get_servers():
                 pull_server_data(force=True)
                 time.sleep(2)
                 pass
-    
+
+        # time.sleep(2)
+
+    if len(server_data) == 0:
+        return False
+
     servers = server_data["LogicalServers"]
 
     user_tier = int(get_config_value("USER", "tier"))
@@ -150,15 +160,18 @@ def set_config_value(group, key, value):
         config.write(f)
 
 
-def get_ip_info(gui_enbled=False):
+def get_ip_info(gui_enabled=False):
     """Return the current public IP Address"""
     logger.debug("Getting IP Information")
-    ip_info = call_api("/vpn/location")
+    ip_info = call_api("/vpn/location", gui_enabled=gui_enabled)
+
+    if ip_info == None:
+        return False
 
     ip = ip_info["IP"]
     isp = ip_info["ISP"]
 
-    if gui_enbled == True:
+    if gui_enabled == True:
         return ip, isp, ip_info["Country"]
     return ip, isp
 

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.4.0"
+VERSION = "1.5.0"
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
 PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/protonvpn-autoconnect.service"
 TEMPLATE ="""

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -240,6 +240,9 @@ class Handler:
         about_dialog = self.interface.get_object("AboutDialog")
         about_dialog.set_version(VERSION)
         about_dialog.show()
+
+    def diagnose_menu_button_clicked(self, button):
+        print("To-do")
     
     def check_for_updates_button_clicked(self, button):
         messagedialog_window = self.interface.get_object("MessageDialog")

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -118,6 +118,7 @@ class Handler:
 
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         # Get the server list object
@@ -149,6 +150,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Connecting to the fastest server...")
@@ -165,6 +167,7 @@ class Handler:
         """   
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         try:
@@ -190,6 +193,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Connecting to a random server...")
@@ -206,6 +210,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Disconnecting...")
@@ -223,6 +228,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Refreshing server list...")
@@ -244,12 +250,13 @@ class Handler:
     def diagnose_menu_button_clicked(self, button):
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label")
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Diagnosing...")
         messagedialog_spinner.show()
 
-        thread = Thread(target=message_dialog, args=[self.interface, "diagnose", messagedialog_label, messagedialog_spinner])
+        thread = Thread(target=message_dialog, args=[self.interface, "diagnose", messagedialog_label, messagedialog_spinner, messagedialog_sub_label])
         thread.daemon = True
         thread.start()
         
@@ -258,6 +265,7 @@ class Handler:
     def check_for_updates_button_clicked(self, button):
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Checking...")
@@ -309,6 +317,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Updating username and password...")
@@ -340,6 +349,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
 
         messagedialog_label.set_markup("Updating DNS configurations...")
@@ -356,6 +366,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         messagedialog_label.set_markup("Updating ProtonVPN Plan...")
@@ -373,6 +384,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         messagedialog_label.set_markup("Updating default OpenVPN Protocol...")
@@ -401,6 +413,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         messagedialog_label.set_markup("Updating killswitch configurations...")
@@ -419,6 +432,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         messagedialog_label.set_markup("Updating split tunneling configurations...")
@@ -436,6 +450,7 @@ class Handler:
         """
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
         messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
         
         messagedialog_label.set_markup("Purging configurations configurations...")

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -242,8 +242,19 @@ class Handler:
         about_dialog.show()
 
     def diagnose_menu_button_clicked(self, button):
-        print("To-do")
-    
+        messagedialog_window = self.interface.get_object("MessageDialog")
+        messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
+
+        messagedialog_label.set_markup("Diagnosing...")
+        messagedialog_spinner.show()
+
+        thread = Thread(target=message_dialog, args=[self.interface, "diagnose", messagedialog_label, messagedialog_spinner])
+        thread.daemon = True
+        thread.start()
+        
+        messagedialog_window.show()
+        
     def check_for_updates_button_clicked(self, button):
         messagedialog_window = self.interface.get_object("MessageDialog")
         messagedialog_label = self.interface.get_object("message_dialog_label")

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -65,7 +65,7 @@ class Handler:
         """Button/Event handler to intialize user account. Calls populate_server_list(server_list_object) to populate server list.
         """     
         login_window = self.interface.get_object("LoginWindow")
-        user_window = self.interface.get_object("Dashboard")
+        user_window = self.interface.get_object("DashboardWindow")
 
         with concurrent.futures.ThreadPoolExecutor() as executor:
             future = executor.submit(on_login, self.interface)
@@ -490,10 +490,10 @@ def initialize_gui():
 
     if not os.path.isfile(CONFIG_FILE):
         window = interface.get_object("LoginWindow")
-        dashboard = interface.get_object("Dashboard")
+        dashboard = interface.get_object("DashboardWindow")
         dashboard.connect("destroy", Gtk.main_quit)
     else:
-        window = interface.get_object("Dashboard")
+        window = interface.get_object("DashboardWindow")
         window.connect("destroy", Gtk.main_quit)
         load_on_start(interface)
     

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -509,7 +509,7 @@ def initialize_gui():
     else:
         window = interface.get_object("DashboardWindow")
         window.connect("destroy", Gtk.main_quit)
-        load_on_start(interface)
+        load_on_start(interface, fast_boot=True)
     
     window.show()
     

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1,149 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkAboutDialog" id="AboutDialog">
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">ProtonVPN GUI - About</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon">protonvpn_logo.png</property>
-    <property name="type_hint">dialog</property>
-    <property name="urgency_hint">True</property>
-    <property name="accept_focus">False</property>
-    <property name="focus_on_map">False</property>
-    <property name="gravity">center</property>
-    <property name="program_name">Unofficial ProntVPN GUI for Linux</property>
-    <property name="comments" translatable="yes">Based on protonvpn-cli-ng</property>
-    <property name="website">https://github.com/calexandru2018/protonvpn-linux-gui</property>
-    <property name="website_label" translatable="yes">Github</property>
-    <property name="authors">ProtonVPN CLI: Rafficer and ProtonVPN
-ProtonVPN Unofficial GUI: calexandru2018</property>
-    <property name="logo">protonvpn_logo_full.png</property>
-    <property name="license_type">gpl-3-0</property>
-    <signal name="delete-event" handler="AboutDialog_delete_event" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox">
-        <property name="can_focus">False</property>
-        <property name="valign">center</property>
-        <property name="margin_left">15</property>
-        <property name="margin_right">15</property>
-        <property name="margin_top">30</property>
-        <property name="margin_bottom">30</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="homogeneous">True</property>
-            <property name="layout_style">spread</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="row_homogeneous">True</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkButtonBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="spacing">20</property>
-                <property name="layout_style">start</property>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <object class="GtkButton" id="check_for_updates_button">
-                    <property name="label" translatable="yes">Update</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <signal name="clicked" handler="check_for_updates_button_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="help_button">
-                    <property name="label" translatable="yes">Help</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <signal name="clicked" handler="help_button_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">4</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-                <property name="width">3</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child type="center">
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
   <object class="GtkListStore" id="DNSListStore">
     <columns>
       <!-- column-name ID -->
@@ -201,7 +59,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="gravity">west</property>
     <signal name="delete-event" handler="ConfigurationsWindow_delete_event" swapped="no"/>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -941,14 +799,14 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="can_focus">True</property>
     <property name="is_focus">True</property>
     <property name="title" translatable="yes">ProtonVPN GUI - Login</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">440</property>
     <property name="default_height">250</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="gravity">center</property>
     <property name="has_resize_grip">True</property>
     <property name="show_menubar">False</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -1328,11 +1186,14 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="title" translatable="yes">ProtonVPN GUI</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
+    <property name="window_position">center</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
     <property name="skip_pager_hint">True</property>
-    <child>
+    <property name="gravity">center</property>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child internal-child="vbox">
@@ -1429,13 +1290,13 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
       <column type="gchararray"/>
     </columns>
   </object>
-  <object class="GtkApplicationWindow" id="Dashboard">
+  <object class="GtkApplicationWindow" id="DashboardWindow">
     <property name="can_focus">True</property>
     <property name="has_focus">True</property>
     <property name="is_focus">True</property>
     <property name="no_show_all">True</property>
     <property name="title" translatable="yes">ProtonVPN GUI - Dashboard</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">440</property>
     <property name="default_height">250</property>
     <property name="icon">protonvpn_logo.png</property>
@@ -2325,6 +2186,149 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
           </packing>
         </child>
         <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkAboutDialog" id="AboutDialog">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">ProtonVPN GUI - About</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="window_position">center-always</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon">protonvpn_logo.png</property>
+    <property name="type_hint">dialog</property>
+    <property name="urgency_hint">True</property>
+    <property name="accept_focus">False</property>
+    <property name="focus_on_map">False</property>
+    <property name="gravity">center</property>
+    <property name="attached_to">DashboardWindow</property>
+    <property name="program_name">Unofficial ProntVPN GUI for Linux</property>
+    <property name="comments" translatable="yes">Based on protonvpn-cli-ng</property>
+    <property name="website">https://github.com/calexandru2018/protonvpn-linux-gui</property>
+    <property name="website_label" translatable="yes">Github</property>
+    <property name="authors">ProtonVPN CLI: Rafficer and ProtonVPN
+ProtonVPN Unofficial GUI: calexandru2018</property>
+    <property name="logo">protonvpn_logo_full.png</property>
+    <property name="license_type">gpl-3-0</property>
+    <signal name="delete-event" handler="AboutDialog_delete_event" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin_left">15</property>
+        <property name="margin_right">15</property>
+        <property name="margin_top">30</property>
+        <property name="margin_bottom">30</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">spread</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="row_homogeneous">True</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">20</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <object class="GtkButton" id="check_for_updates_button">
+                    <property name="label" translatable="yes">Update</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="check_for_updates_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="help_button">
+                    <property name="label" translatable="yes">Help</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="help_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child type="center">
           <placeholder/>
         </child>
       </object>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1201,8 +1201,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="is_focus">True</property>
-        <property name="margin_left">20</property>
-        <property name="margin_right">20</property>
+        <property name="margin_left">25</property>
+        <property name="margin_right">25</property>
         <property name="margin_top">20</property>
         <property name="margin_bottom">20</property>
         <property name="orientation">vertical</property>
@@ -1244,7 +1244,6 @@
             <property name="valign">center</property>
             <property name="margin_top">30</property>
             <property name="margin_bottom">30</property>
-            <property name="label" translatable="yes">label</property>
             <property name="wrap">True</property>
             <property name="selectable">True</property>
             <property name="width_chars">40</property>
@@ -1256,15 +1255,34 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="message_dialog_sub_label">
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_top">15</property>
+            <property name="margin_bottom">30</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
+            <property name="width_chars">40</property>
+            <property name="max_width_chars">70</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
-        <child type="center">
+        <child>
           <object class="GtkSpinner" id="message_dialog_spinner">
             <property name="width_request">50</property>
             <property name="height_request">50</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_bottom">50</property>
             <property name="active">True</property>
           </object>
           <packing>
@@ -1457,6 +1475,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">30</property>
+                <property name="margin_right">100</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>
@@ -1522,7 +1541,6 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Running</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -1560,7 +1578,6 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -1695,7 +1712,7 @@
               <object class="GtkGrid" id="right_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">100</property>
+                <property name="margin_right">20</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -1290,6 +1290,17 @@
       <column type="gchararray"/>
     </columns>
   </object>
+  <object class="GtkImage" id="gtk-execute">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-execute</property>
+    <property name="use_fallback">True</property>
+  </object>
+  <object class="GtkImage" id="gtk-preferences">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-preferences</property>
+  </object>
   <object class="GtkApplicationWindow" id="DashboardWindow">
     <property name="can_focus">True</property>
     <property name="has_focus">True</property>
@@ -1326,11 +1337,11 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="configurations_menu_button">
-                        <property name="label">gtk-preferences</property>
+                        <property name="label">Configurations</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
+                        <property name="image">gtk-preferences</property>
+                        <property name="use_stock">False</property>
                         <property name="always_show_image">True</property>
                         <signal name="activate" handler="configuration_menu_button_clicked" swapped="no"/>
                       </object>
@@ -1374,6 +1385,17 @@
                         <property name="use_stock">True</property>
                         <property name="always_show_image">True</property>
                         <signal name="activate" handler="about_menu_button_clicked" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="diagnose_menu_button">
+                        <property name="label">Diagnose</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="image">gtk-execute</property>
+                        <property name="use_stock">False</property>
+                        <property name="always_show_image">True</property>
+                        <signal name="activate" handler="diagnose_menu_button_clicked" swapped="no"/>
                       </object>
                     </child>
                   </object>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1290,6 +1290,17 @@
       <column type="gchararray"/>
     </columns>
   </object>
+  <object class="GtkImage" id="gtk-execute">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-execute</property>
+    <property name="use_fallback">True</property>
+  </object>
+  <object class="GtkImage" id="gtk-preferences">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-preferences</property>
+  </object>
   <object class="GtkApplicationWindow" id="DashboardWindow">
     <property name="can_focus">True</property>
     <property name="has_focus">True</property>
@@ -1326,11 +1337,11 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkImageMenuItem" id="configurations_menu_button">
-                        <property name="label">gtk-preferences</property>
+                        <property name="label">Configurations</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
+                        <property name="image">gtk-preferences</property>
+                        <property name="use_stock">False</property>
                         <property name="always_show_image">True</property>
                         <signal name="activate" handler="configuration_menu_button_clicked" swapped="no"/>
                       </object>
@@ -1374,6 +1385,16 @@
                         <property name="use_stock">True</property>
                         <property name="always_show_image">True</property>
                         <signal name="activate" handler="about_menu_button_clicked" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkImageMenuItem" id="diagnose_menu_button">
+                        <property name="label">Diagnose</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="image">gtk-execute</property>
+                        <property name="use_stock">False</property>
+                        <property name="always_show_image">True</property>
                       </object>
                     </child>
                   </object>
@@ -2196,14 +2217,14 @@
     <property name="title" translatable="yes">ProtonVPN GUI - About</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
-    <property name="gravity">center</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="type_hint">dialog</property>
     <property name="urgency_hint">True</property>
     <property name="accept_focus">False</property>
     <property name="focus_on_map">False</property>
+    <property name="gravity">center</property>
     <property name="attached_to">DashboardWindow</property>
     <property name="program_name">Unofficial ProntVPN GUI for Linux</property>
     <property name="comments" translatable="yes">Based on protonvpn-cli-ng</property>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1,149 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkAboutDialog" id="AboutDialog">
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">ProtonVPN GUI - About</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon">protonvpn_logo.png</property>
-    <property name="type_hint">dialog</property>
-    <property name="urgency_hint">True</property>
-    <property name="accept_focus">False</property>
-    <property name="focus_on_map">False</property>
-    <property name="gravity">center</property>
-    <property name="program_name">Unofficial ProntVPN GUI for Linux</property>
-    <property name="comments" translatable="yes">Based on protonvpn-cli-ng</property>
-    <property name="website">https://github.com/calexandru2018/protonvpn-linux-gui</property>
-    <property name="website_label" translatable="yes">Github</property>
-    <property name="authors">ProtonVPN CLI: Rafficer and ProtonVPN
-ProtonVPN Unofficial GUI: calexandru2018</property>
-    <property name="logo">protonvpn_logo_full.png</property>
-    <property name="license_type">gpl-3-0</property>
-    <signal name="delete-event" handler="AboutDialog_delete_event" swapped="no"/>
-    <child>
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox">
-        <property name="can_focus">False</property>
-        <property name="valign">center</property>
-        <property name="margin_left">15</property>
-        <property name="margin_right">15</property>
-        <property name="margin_top">30</property>
-        <property name="margin_bottom">30</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="homogeneous">True</property>
-            <property name="layout_style">spread</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <placeholder/>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="row_homogeneous">True</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkButtonBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="spacing">20</property>
-                <property name="layout_style">start</property>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <object class="GtkButton" id="check_for_updates_button">
-                    <property name="label" translatable="yes">Update</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <signal name="clicked" handler="check_for_updates_button_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkButton" id="help_button">
-                    <property name="label" translatable="yes">Help</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <signal name="clicked" handler="help_button_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">4</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-                <property name="width">3</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child type="center">
-          <placeholder/>
-        </child>
-      </object>
-    </child>
-  </object>
   <object class="GtkListStore" id="DNSListStore">
     <columns>
       <!-- column-name ID -->
@@ -201,7 +59,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="gravity">west</property>
     <signal name="delete-event" handler="ConfigurationsWindow_delete_event" swapped="no"/>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -894,7 +752,7 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
                         <property name="halign">center</property>
                         <property name="valign">end</property>
                         <property name="margin_top">10</property>
-                        <signal name="clicked" handler="update_killswtich_button_clicked" swapped="no"/>
+                        <signal name="clicked" handler="update_killswitch_button_clicked" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -941,14 +799,14 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="can_focus">True</property>
     <property name="is_focus">True</property>
     <property name="title" translatable="yes">ProtonVPN GUI - Login</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">440</property>
     <property name="default_height">250</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="gravity">center</property>
     <property name="has_resize_grip">True</property>
     <property name="show_menubar">False</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -1328,11 +1186,14 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
     <property name="title" translatable="yes">ProtonVPN GUI</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
+    <property name="window_position">center</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon">protonvpn_logo.png</property>
     <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
     <property name="skip_pager_hint">True</property>
-    <child>
+    <property name="gravity">center</property>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child internal-child="vbox">
@@ -1429,13 +1290,13 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
       <column type="gchararray"/>
     </columns>
   </object>
-  <object class="GtkApplicationWindow" id="Dashboard">
+  <object class="GtkApplicationWindow" id="DashboardWindow">
     <property name="can_focus">True</property>
     <property name="has_focus">True</property>
     <property name="is_focus">True</property>
     <property name="no_show_all">True</property>
     <property name="title" translatable="yes">ProtonVPN GUI - Dashboard</property>
-    <property name="window_position">center</property>
+    <property name="window_position">center-always</property>
     <property name="default_width">440</property>
     <property name="default_height">250</property>
     <property name="icon">protonvpn_logo.png</property>
@@ -2325,6 +2186,149 @@ ProtonVPN Unofficial GUI: calexandru2018</property>
           </packing>
         </child>
         <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkAboutDialog" id="AboutDialog">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">ProtonVPN GUI - About</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="gravity">center</property>
+    <property name="window_position">center</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon">protonvpn_logo.png</property>
+    <property name="type_hint">dialog</property>
+    <property name="urgency_hint">True</property>
+    <property name="accept_focus">False</property>
+    <property name="focus_on_map">False</property>
+    <property name="attached_to">DashboardWindow</property>
+    <property name="program_name">Unofficial ProntVPN GUI for Linux</property>
+    <property name="comments" translatable="yes">Based on protonvpn-cli-ng</property>
+    <property name="website">https://github.com/calexandru2018/protonvpn-linux-gui</property>
+    <property name="website_label" translatable="yes">Github</property>
+    <property name="authors">ProtonVPN CLI: Rafficer and ProtonVPN
+ProtonVPN Unofficial GUI: calexandru2018</property>
+    <property name="logo">protonvpn_logo_full.png</property>
+    <property name="license_type">gpl-3-0</property>
+    <signal name="delete-event" handler="AboutDialog_delete_event" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="valign">center</property>
+        <property name="margin_left">15</property>
+        <property name="margin_right">15</property>
+        <property name="margin_top">30</property>
+        <property name="margin_bottom">30</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">spread</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <placeholder/>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="row_homogeneous">True</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="spacing">20</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <object class="GtkButton" id="check_for_updates_button">
+                    <property name="label" translatable="yes">Update</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="check_for_updates_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="help_button">
+                    <property name="label" translatable="yes">Help</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <signal name="clicked" handler="help_button_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">4</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+                <property name="width">3</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child type="center">
           <placeholder/>
         </child>
       </object>

--- a/protonvpn_linux_gui/resources/main.glade~
+++ b/protonvpn_linux_gui/resources/main.glade~
@@ -1201,8 +1201,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="is_focus">True</property>
-        <property name="margin_left">20</property>
-        <property name="margin_right">20</property>
+        <property name="margin_left">25</property>
+        <property name="margin_right">25</property>
         <property name="margin_top">20</property>
         <property name="margin_bottom">20</property>
         <property name="orientation">vertical</property>
@@ -1244,7 +1244,6 @@
             <property name="valign">center</property>
             <property name="margin_top">30</property>
             <property name="margin_bottom">30</property>
-            <property name="label" translatable="yes">label</property>
             <property name="wrap">True</property>
             <property name="selectable">True</property>
             <property name="width_chars">40</property>
@@ -1256,15 +1255,34 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="message_dialog_sub_label">
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_top">15</property>
+            <property name="margin_bottom">20</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
+            <property name="width_chars">40</property>
+            <property name="max_width_chars">70</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
           </packing>
         </child>
-        <child type="center">
+        <child>
           <object class="GtkSpinner" id="message_dialog_spinner">
             <property name="width_request">50</property>
             <property name="height_request">50</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_bottom">50</property>
             <property name="active">True</property>
           </object>
           <packing>
@@ -1395,6 +1413,7 @@
                         <property name="image">gtk-execute</property>
                         <property name="use_stock">False</property>
                         <property name="always_show_image">True</property>
+                        <signal name="activate" handler="diagnose_menu_button_clicked" swapped="no"/>
                       </object>
                     </child>
                   </object>
@@ -1456,6 +1475,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">30</property>
+                <property name="margin_right">100</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>
@@ -1521,7 +1541,6 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Running</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -1559,7 +1578,6 @@
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">Custom</property>
                     <property name="justify">fill</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -1694,7 +1712,7 @@
               <object class="GtkGrid" id="right_dashboard_grid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">100</property>
+                <property name="margin_right">20</property>
                 <property name="column_spacing">20</property>
                 <property name="row_homogeneous">True</property>
                 <child>

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -32,13 +32,14 @@ def message_dialog(interface, action, label_object, spinner_object):
     # time.sleep(1)
     # messagedialog_window = interface.get_object("MessageDialog")
     if action == "check_for_update":
-
         with concurrent.futures.ThreadPoolExecutor() as executor:
             future = executor.submit(check_for_updates)
             return_value = future.result()
 
             label_object.set_markup("<span>{0}</span>".format(return_value))
             spinner_object.hide()
+    elif action == "diagnose":
+        print("Diagnose")
 
 def check_for_updates():
 

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -39,7 +39,23 @@ def message_dialog(interface, action, label_object, spinner_object):
             label_object.set_markup("<span>{0}</span>".format(return_value))
             spinner_object.hide()
     elif action == "diagnose":
-        print("Diagnose")
+        result = '' 
+        # Check if there is internet connection
+            # Depending on next questions, some actions might be suggested.
+
+        # Check if killswitch is enabled
+            # Advice to restore IP tables manually and restart netowrk manager.
+
+        # Check if VPN is running
+            # If there is a OpenVPN process running in the background, kill it.
+
+        # Check if custom DNS is current
+            # If there is no VPN connection and also no internet, then it is a DNS issue.
+
+        # Check if servers are cached
+            # Maybe to-do
+        label_object.set_markup("To-do")
+        spinner_object.hide()
 
 def check_for_updates():
 

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -41,6 +41,13 @@ def message_dialog(interface, action, label_object, spinner_object, sub_label_ob
             spinner_object.hide()
     elif action == "diagnose":
         reccomendation = '' 
+
+        end_openvpn_process_guide = """\n
+        sudo pkill openvpn\n
+        or\n
+        sudo pkill -9 openvpn
+        """
+
         restore_ip_tables_guide ="""\n
         sudo iptables -F
         sudo iptables -P INPUT ACCEPT
@@ -94,7 +101,6 @@ def message_dialog(interface, action, label_object, spinner_object, sub_label_ob
                         is_custom_resolv_conf["logical"] = True
                         is_custom_resolv_conf["display"] = "Custom"
         try:
-            print("Trying split tunnel")
             is_splitunn_enabled = True if get_config_value("USER", "split_tunnel") == "1" else False
         except KeyError:
             is_splitunn_enabled = False
@@ -105,20 +111,18 @@ def message_dialog(interface, action, label_object, spinner_object, sub_label_ob
         # Reccomendations based on known issues
         if not has_internet:
             if is_ovpnprocess_running:
-                reccomendation = reccomendation + "\nYou have no internet conneciton though a OpenVPN process is running, try to kill the process first."
+                reccomendation = reccomendation + "\nYou have no internet conneciton and a VPN process is running, try to kill the process first:" + end_openvpn_process_guide
             elif not is_ovpnprocess_running:
                 if is_killswitch_enabled:
                     reccomendation = reccomendation + "\nYou Have killswitch enabled, which might be blocking your connection.\nTry to flush and then reconfigure your IP tables:" + restore_ip_tables_guide
                 elif is_custom_resolv_conf["logical"] == True:
-                    reccomendation = reccomendation + "\nCustom DNS is still present in resolv.conf.\nTry to restart your network manager to restore to default configurations:" + restart_netwman_guide
+                    reccomendation = reccomendation + "\nCustom DNS is still present in resolv.conf even though you are not connected to a server.\nTry to restart your network manager to restore default configurations:" + restart_netwman_guide
                 elif is_custom_resolv_conf["logical"] == None:
-                    reccomendation = reccomendation + "\nNo DNS settings is present in resolv.conf.\nTry to restart your network manager to restore to default configurations:" + restart_netwman_guide
+                    reccomendation = reccomendation + "\nNo running VPN process was found, though DNS configurations are lacking in resolv.conf. This might be due to some error or corruption during restoration.\nTry to restart your network manager to restore default configurations:" + restart_netwman_guide
                 else:
                     reccomendation = "\nYou have no internet connection.\nTry to connect to a different nework to resolve the issue."
             else:
                 reccomendation = "<b>Unkown problem!</b>"
-        elif not has_internet and is_custom_resolv_conf["logical"] == True:
-            reccomendation = "\nCustom DNS is still present in resolv.conf.\nTry to restart your network manager to restore to default configurations.\nsudo systemctl restart NetworkManager:" + restart_netwman_guide 
         else:
             reccomendation = "\nYour system seems to be ok. There are no reccomendations at the moment."
 

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -552,6 +552,8 @@ def stop_and_disable_daemon():
 
     return True
 
-    
+def get_gui_processes():
+        processes = subprocess.run(["pgrep", "protonvpn-gui"],stdout=subprocess.PIPE)
 
+        return list(filter(None, processes.stdout.decode().split("\n"))) 
     


### PR DESCRIPTION
**FIX**
 - Upon GUI crash, a shadow process would still continue to work in the background, and the only way to end it was by going into the task manager or using pkill or kill to end the process. This was now fixed so that when a user start a new GUI window/session, it will identify that there are two processes running and kill the old one.
 - Another GUI crash was being caused when a user would launch the GUI without internet access. Since the server population list function needs information about the servers, this caused a out of range index problem. This issue has now been also fixed.

**FEATURE**
 - Added a new diagnosis tool. This tool will try to identify the main connectivity problems, by checking at common problematic causes. After making a diagnosis, the tool will give the user a summary. It will also give the user some basic code snippets that can be easily copied/pasted into a terminal to easily resolve any experienced issues, even without an internet connection (this presupposes that the lack of internet connectivity is caused by some misconfigurationism of the DNS, killswitch or shadow openvpn process).
   - In the case of killswitch, it will give a user instructions on how to flush iptables and how to restore them to default state.
   - In the case of DNS missconfiguration, it will give a user instructions on how to restart network manager.
   - In the case of blocking openvpn process, it will give a user instructions on how to end the process.