### PR TITLE
 Autoconnect (Start on boot); Updated "Help" text

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
 
 [packages]
 docopt = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "77c4532a5205db23195903cbec9c98326729ed2c9329ac0871fa950ba127096c"
+            "sha256": "75b904fffcbe5aa10ca0dba3c8ea2df06a3fc90fefc46d5c1fd02a0ad97aea0c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -82,5 +82,70 @@
             "version": "==1.25.8"
         }
     },
-    "develop": {}
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c",
+                "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"
+            ],
+            "version": "==8.2.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3",
+                "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"
+            ],
+            "version": "==20.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
+            ],
+            "version": "==1.8.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+            ],
+            "version": "==2.4.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
+                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+            ],
+            "version": "==0.1.8"
+        }
+    }
 }

--- a/custom_pvpn_cli_ng/protonvpn_cli/cli.py
+++ b/custom_pvpn_cli_ng/protonvpn_cli/cli.py
@@ -162,6 +162,7 @@ def init_cli(gui_enabled=False, gui_user_input=False):
             "dns_leak_protection": "1",
             "custom_dns": "None",
             "check_update_interval": "3",
+            "autoconnect": "0"
         }
         config["metadata"] = {
             "last_api_pull": "0",
@@ -260,6 +261,7 @@ def init_cli(gui_enabled=False, gui_user_input=False):
         set_config_value("USER", "dns_leak_protection", 1)
         set_config_value("USER", "custom_dns", None)
         set_config_value("USER", "killswitch", 0)
+        set_config_value("USER", "autoconnect", "0")
 
         with open(PASSFILE, "w") as f:
             f.write("{0}\n{1}".format(ovpn_username, ovpn_password))

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -10,6 +10,7 @@ Wants=network-online.target
 [Service]
 Type=forking
 ExecStart=PATH
+ExecStop=STOP
 Environment=PVPN_WAIT=300
 Environment=PVPN_DEBUG=1
 Environment=SUDO_USER=user

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -1,9 +1,10 @@
 VERSION = "1.5.4"
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
-PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/protonvpn-autoconnect.service"
+SERVICE_NAME = "custompvpn-autoconnect" 
+PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/{}.service".format(SERVICE_NAME)
 TEMPLATE ="""
 [Unit]
-Description=ProtonVPN-CLI auto-connect
+Description=Custom ProtonVPN-CLI auto-connect
 Wants=network-online.target
 
 [Service]
@@ -16,3 +17,4 @@ Environment=SUDO_USER=user
 [Install]
 WantedBy=multi-user.target
 """
+# run whoami for username

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -1,4 +1,5 @@
-VERSION = "1.5.4"
+from custom_pvpn_cli_ng.protonvpn_cli.constants import VERSION as cli_version
+VERSION = "1.6.0"
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
 SERVICE_NAME = "custompvpn-autoconnect" 
 PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/{}.service".format(SERVICE_NAME)
@@ -18,4 +19,24 @@ Environment=SUDO_USER=user
 [Install]
 WantedBy=multi-user.target
 """
-# run whoami for username
+HELP_TEXT = """
+<b>How is this GUI related to protonvpn-cli-ng ?</b>
+This GUI is heavily based on the original cli v{cli_version}, though to accomodate certain extra functionality I had to make small tweaks. 
+For code readibility I decided to separate the GUI and the CLI into two different packages.
+
+<b>I am having connectivity issues and I don't know what to do!</b>
+I have a developed a Diagnosis tool that should be helpful in the most cases. You can find the tool under About -> Diagnose.
+This tool will analyse the current configurations and will attempt to help you solve the problem by giving you a brief summary of the root cause.
+It will also provide you some code snippets that you can easily copy/paste into a terminal, even when without internet. If the same issue persists after multiple attempts (to resolve it), try to restart your computer
+
+<b>I am still experiecing problems, to who should I create ticket/issue ?</b>
+If you are experiencing any issues, then you should first contact me, either through github or creating a issue. 
+If, after a closer inspection, I notice that the problem originates from within the CLI, then I would then reccomend you to contact protonvpn support instead.
+
+<b>I would like to suggest a feature, where could I do that ?</b>
+If you would like me to implement a new feature or want to give suggestion for one, then you can do it by creating a github issue, select the type of issue, in this case a Feature request.
+Then fill in the template and concisely explain what you would like to see implemented, with as much detail as possible.
+
+<b>I woule like to donate, do you have any e-wallets ?</b>
+First of all, thank you! Any help is very much appreciated and welcome, all this is developed during my free time. If you would like to donate, at the moment I have a liberapay account: https://liberapay.com/calexandru2018
+""".format(cli_version=cli_version)

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -45,7 +45,8 @@ from .thread_functions import(
     update_split_tunneling,
     purge_configurations,
     kill_duplicate_gui_process,
-    load_content_on_start
+    load_content_on_start,
+    update_autoconnect
 )
 
 # Import version
@@ -453,6 +454,24 @@ class Handler:
         gui_logger.debug(">>> Starting \"update_def_protocol\" thread.")
 
         thread = Thread(target=update_def_protocol, args=[self.interface, messagedialog_label, messagedialog_spinner])
+        thread.daemon = True
+        thread.start()
+
+        messagedialog_window.show()
+    
+    # Autoconnect on boot
+    def autoconnect_button_clicked(self, button):
+        messagedialog_window = self.interface.get_object("MessageDialog")
+        messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
+        messagedialog_spinner = self.interface.get_object("message_dialog_spinner")
+        
+        messagedialog_label.set_markup("Updating autoconnect settings...")
+        messagedialog_spinner.show()
+
+        gui_logger.debug(">>> Starting \"update_def_protocol\" thread.")
+
+        thread = Thread(target=update_autoconnect, args=[self.interface, messagedialog_label, messagedialog_spinner])
         thread.daemon = True
         thread.start()
 

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -469,7 +469,7 @@ class Handler:
         messagedialog_label.set_markup("Updating autoconnect settings...")
         messagedialog_spinner.show()
 
-        gui_logger.debug(">>> Starting \"update_def_protocol\" thread.")
+        gui_logger.debug(">>> Starting \"autoconnect_button_clicked\" thread.")
 
         thread = Thread(target=update_autoconnect, args=[self.interface, messagedialog_label, messagedialog_spinner])
         thread.daemon = True

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -50,7 +50,7 @@ from .thread_functions import(
 )
 
 # Import version
-from .constants import VERSION
+from .constants import VERSION, HELP_TEXT
 
 # PyGObject import
 import gi
@@ -282,7 +282,7 @@ class Handler:
         """Button /Event handlerto open About dialog
         """
         about_dialog = self.interface.get_object("AboutDialog")
-        about_dialog.set_version(VERSION)
+        about_dialog.set_version("v."+VERSION)
         about_dialog.show()
 
     def diagnose_menu_button_clicked(self, button):
@@ -321,8 +321,15 @@ class Handler:
         messagedialog_window.show()
 
     def help_button_clicked(self, button):
-        # To-do
-        print("To-do show help.")
+        messagedialog_window = self.interface.get_object("MessageDialog")
+        messagedialog_label = self.interface.get_object("message_dialog_label")
+        messagedialog_sub_label = self.interface.get_object("message_dialog_sub_label").hide()
+        messagedialog_spinner = self.interface.get_object("message_dialog_spinner").hide()
+
+        messagedialog_label.set_markup(HELP_TEXT)
+
+        messagedialog_window.show()
+
 
     def close_message_dialog(self, button):
         self.interface.get_object("MessageDialog").hide()

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -2,6 +2,14 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkListStore" id="AutoconnectListStore">
+    <columns>
+      <!-- column-name ID -->
+      <column type="gchararray"/>
+      <!-- column-name Description -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkListStore" id="DNSListStore">
     <columns>
       <!-- column-name ID -->
@@ -560,7 +568,12 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">[purge disclaimer message]</property>
+                        <property name="label" translatable="yes">By purging your configurations, all af your saved data such as username, password, cached servers, logs and previous connection information will be lost!</property>
+                        <property name="justify">fill</property>
+                        <property name="wrap">True</property>
+                        <property name="wrap_mode">word-char</property>
+                        <property name="width_chars">1</property>
+                        <property name="max_width_chars">30</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -594,7 +607,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">9</property>
                   </packing>
                 </child>
                 <child>
@@ -678,11 +691,11 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">8</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkGrid" id="dns_management_grid1">
+                  <object class="GtkGrid" id="killlswitch_grid">
                     <property name="width_request">400</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -712,7 +725,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Setting:</property>
+                        <property name="label" translatable="yes">Setting</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -758,6 +771,106 @@
                         <property name="left_attach">1</property>
                         <property name="top_attach">3</property>
                         <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">7</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkGrid" id="autoconnect_grid">
+                    <property name="width_request">400</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_bottom">40</property>
+                    <property name="row_spacing">5</property>
+                    <property name="column_spacing">15</property>
+                    <property name="column_homogeneous">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">Autoconnect on Boot</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="size" value="12000"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                        <property name="width">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="autoconnect_button">
+                        <property name="label" translatable="yes">Update Autoconnect</property>
+                        <property name="width_request">150</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">center</property>
+                        <property name="margin_top">10</property>
+                        <signal name="clicked" handler="autoconnect_button_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="autoconnect_combobox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="model">AutoconnectListStore</property>
+                        <property name="has_frame">False</property>
+                        <property name="entry_text_column">1</property>
+                        <property name="id_column">0</property>
+                        <child>
+                          <object class="GtkCellRendererText"/>
+                          <attributes>
+                            <attribute name="text">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Setting</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>

--- a/protonvpn_linux_gui/thread_functions.py
+++ b/protonvpn_linux_gui/thread_functions.py
@@ -6,7 +6,7 @@ import subprocess
 import concurrent.futures
 
 # Import ProtonVPN methods and utils
-from custom_pvpn_cli_ng.protonvpn_cli.utils import get_config_value, is_valid_ip
+from custom_pvpn_cli_ng.protonvpn_cli.utils import get_config_value, is_valid_ip, set_config_value
 from custom_pvpn_cli_ng.protonvpn_cli import cli
 from custom_pvpn_cli_ng.protonvpn_cli import connection
 from custom_pvpn_cli_ng.protonvpn_cli.country_codes import country_codes
@@ -348,6 +348,21 @@ def update_def_protocol(interface, messagedialog_label, messagedialog_spinner):
     gui_logger.debug(">>> Result: \"{0}\"".format(result))
 
     gui_logger.debug(">>> Ended tasks in \"set_default_protocol\" thread.")   
+
+def update_autoconnect(interface, messagedialog_label, messagedialog_spinner):
+    """Button/Event handler to update Autoconnect  
+    """
+    autoconnect_combobox = interface.get_object("autoconnect_combobox")
+    active_choice = autoconnect_combobox.get_active()
+
+    gui_logger.debug(">>> Running \"update_autoconnect\".")
+
+    set_config_value("USER", "autoconnect", active_choice)
+
+    messagedialog_label.set_markup("Autoconnect setting updated!")
+    messagedialog_spinner.hide()
+
+    gui_logger.debug(">>> Ended tasks in \"set_default_protocol\" thread.") 
 
 def update_killswitch(interface, messagedialog_label, messagedialog_spinner):
     """Button/Event handler to update Killswitch  

--- a/protonvpn_linux_gui/thread_functions.py
+++ b/protonvpn_linux_gui/thread_functions.py
@@ -20,7 +20,9 @@ from .utils import (
     load_configurations,
     is_connected,
     update_labels_server_list,
-    get_gui_processes
+    get_gui_processes,
+    manage_autoconnect,
+    populate_autoconnect_list
 )
 
 # Import GUI logger
@@ -354,15 +356,42 @@ def update_autoconnect(interface, messagedialog_label, messagedialog_spinner):
     """
     autoconnect_combobox = interface.get_object("autoconnect_combobox")
     active_choice = autoconnect_combobox.get_active()
+    selected_country = False 
 
     gui_logger.debug(">>> Running \"update_autoconnect\".")
 
     set_config_value("USER", "autoconnect", active_choice)
 
+    # autoconnect_alternatives = ["dis", "fast", "rand", "p2p", "sc", "tor"]
+    manage_autoconnect(mode="disable")
+
+    if active_choice == 1:
+        manage_autoconnect(mode="enable", command="connect -f")
+    elif active_choice == 2:
+        manage_autoconnect(mode="enable", command="connect -r")
+    elif active_choice == 3:
+        manage_autoconnect(mode="enable", command="connect --p2p")
+    elif active_choice == 4:
+        manage_autoconnect(mode="enable", command="connect --sc")
+    elif active_choice == 5:
+        manage_autoconnect(mode="enable", command="connect --tor")
+    elif active_choice > 5:
+        # Connect to a specific country
+        country_list = populate_autoconnect_list(interface, return_list=True)
+        selected_country = country_list[active_choice]
+        for k, v in country_codes.items():
+            if v == selected_country:
+                selected_country = k
+                break
+        if not selected_country:
+            print("[!] Unable to find country code")
+            return False
+        manage_autoconnect(mode="enable", command="connect --cc " + selected_country.upper())
+
     messagedialog_label.set_markup("Autoconnect setting updated!")
     messagedialog_spinner.hide()
 
-    gui_logger.debug(">>> Ended tasks in \"set_default_protocol\" thread.") 
+    gui_logger.debug(">>> Ended tasks in \"update_autoconnect\" thread.") 
 
 def update_killswitch(interface, messagedialog_label, messagedialog_spinner):
     """Button/Event handler to update Killswitch  

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -20,9 +20,9 @@ from custom_pvpn_cli_ng.protonvpn_cli.utils import (
 
 from custom_pvpn_cli_ng.protonvpn_cli.country_codes import country_codes
 
-from custom_pvpn_cli_ng.protonvpn_cli.constants import SPLIT_TUNNEL_FILE
+from custom_pvpn_cli_ng.protonvpn_cli.constants import SPLIT_TUNNEL_FILE, USER
 
-from .constants import PATH_AUTOCONNECT_SERVICE, TEMPLATE, VERSION, GITHUB_URL_RELEASE
+from .constants import PATH_AUTOCONNECT_SERVICE, TEMPLATE, VERSION, GITHUB_URL_RELEASE, SERVICE_NAME
 
 from .gui_logger import gui_logger
 
@@ -604,9 +604,10 @@ def populate_autoconnect_list(interface, return_list=False):
         "fast": "Fastest",
         "rand": "Random", 
         "p2p": "Peer2Peer", 
-        "sc": "Secure Core"
+        "sc": "Secure Core (Plus/Visionary)",
+        "tor": "Tor (Plus/Visionary)"
     }
-    autoconnect_alternatives = ["dis", "fast", "rand", "p2p", "sc"]
+    autoconnect_alternatives = ["dis", "fast", "rand", "p2p", "sc", "tor"]
     return_values = []
     for server in servers:
         country = get_country_name(server["ExitCountry"])
@@ -640,37 +641,43 @@ def populate_autoconnect_list(interface, return_list=False):
 #
 # Autoconnect
 
-def manage_autoconnect(mode):
+def manage_autoconnect(mode, command=False):
     """Manages autoconnect functionality
     """
     # Check if protonvpn-cli-ng is installed, and return the path to a CLI
     if mode == 'enable':
 
-        if not enable_autoconnect():
-            print("[!]Unable to enable autoconnect")
-            return
+        if not enable_autoconnect(command):
+            print("[!] Unable to enable autoconnect")
+            gui_logger.debug("[!] Unable to enable autoconnect.")
+            return False
 
         print("Autoconnect on boot enabled")
+        gui_logger.debug(">>> Autoconnect on boot enabled")
+        return True
         
     elif mode == 'disable':
 
         if not disable_autoconnect():
-            print("[!]Could not disable autoconnect")
-            return
+            print("[!] Could not disable autoconnect")
+            gui_logger.debug("[!] Could not disable autoconnect.")
+            return False
 
         print("Autoconnect on boot disabled")
-          
-def enable_autoconnect():
+        gui_logger.debug(">>> Autoconnect on boot disabled")
+        return True
+
+def enable_autoconnect(command):
     """Enables autoconnect
     """
     protonvpn_path = find_cli()
-    command = " connect -f"
     if not protonvpn_path:
         return False
 
     # Fill template with CLI path and username
-    with_cli_path = TEMPLATE.replace("PATH", (protonvpn_path + command))
-    template = with_cli_path.replace("SUDO_USER", get_config_value("USER", "username"))
+    with_cli_path = TEMPLATE.replace("PATH", (protonvpn_path + " " + command))
+    template = with_cli_path.replace("STOP", protonvpn_path + " disconnect")
+    template = template.replace("=user", "="+USER)
     
     if not generate_template(template):
         return False
@@ -695,117 +702,122 @@ def find_cli():
     custom_cli_err = ''
 
     try:
-        protonvpn_path = subprocess.Popen(['sudo', 'which', 'protonvpn'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        protonvpn_path, cli_ng_err = protonvpn_path.communicate()
+        protonvpn_path = subprocess.run(['sudo', 'which', 'protonvpn'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     except:
-        print("[!]protonvpn-cli-ng is not installed.")
+        gui_logger.debug("[!] Unable to run \"find protonvpn-cli-ng\" subprocess.")
+        protonvpn_path = False
 
     # If protonvpn-cli-ng is not installed then attempt to get the path of 'modified protonvpn-cli'
-    if not len(cli_ng_err) == 0:
+    if not protonvpn_path == False and protonvpn_path.returncode == 1:
         try:
-            protonvpn_path = subprocess.Popen(['sudo', 'which', 'custom-pvpn-cli'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            protonvpn_path, custom_cli_err = protonvpn_path.communicate()
+            protonvpn_path = subprocess.run(['sudo', 'which', 'custom-pvpn-cli'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except:
-            print("[!]custom protonvpn-cli is not found.")
+            gui_logger.debug("[!] Unable to run \"find custom protonvpn-cli\" subprocess.")
+            protonvpn_path = False
 
-    if not len(custom_cli_err) == 0:
-        print("In find_cli: custom_cli_err")
-        return False
-
-    # to remove \n
-    return protonvpn_path[:-1].decode()
+    return protonvpn_path.stdout.decode()[:-1] if (not protonvpn_path == False and protonvpn_path.returncode == 0) else False
         
 def generate_template(template):
     """Generates service file
     """
     generate_service_command = "cat > {0} <<EOF {1}\nEOF".format(PATH_AUTOCONNECT_SERVICE, template)
-
+    gui_logger.debug(">>> Template:\n{}".format(generate_service_command))
     try:
-        resp = subprocess.Popen(["sudo", "bash", "-c", generate_service_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, err = resp.communicate()
-    except:
-        print("[!]Could not find create boot file.")
-        return False
+        resp = subprocess.run(["sudo", "bash", "-c", generate_service_command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    if not len(err) == 0:
-        print("In generate_template: ", err)
+        if resp.returncode == 1:
+            gui_logger.debug("[!] Unable to generate template.\n{}".format(resp))
+            return False
+
+        return True
+    except:
+        gui_logger.debug("[!] Could not run \"generate template\" subprocess.")
         return False
-    
-    return True
 
 def remove_template():
     """Remove service file from /etc/systemd/system/
     """
     try:
-        resp = subprocess.Popen(["sudo", "rm", PATH_AUTOCONNECT_SERVICE], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, err = resp.communicate()
+        resp = subprocess.run(["sudo", "rm", PATH_AUTOCONNECT_SERVICE], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        # If return code 1: File does not exist in path
+        # This is fired when a user wants to remove template a that does not exist
+        if resp.returncode == 1:
+            gui_logger.debug("[!] Could not remove .serivce file.\n{}".format(resp))
+
+        reload_daemon()
+        return True
     except:
-        print("[!]Could not remove service file.")
+        gui_logger.debug("[!] Could not run \"remove template\" subprocess.")
         return False  
-
-    # Gives error if file does not exist, should check first if file exists
-    # if not len(err) == 0:
-    #     print("In remove_template: ", err)
-    #     return False
-
-    return True
 
 def enable_daemon():
     """Reloads daemon and enables the autoconnect service
     """
-    try:
-        reload_daemon = subprocess.Popen(['sudo', 'systemctl', 'daemon-reload'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, reload_err = reload_daemon.communicate()
-    except:
-        print("[!]Could not reload daemon.")
-        return False
 
-    if not len(reload_err) == 0:
-        print("In enable_daemon (reload): ", reload_err)
-        return False
+    reload_daemon()
 
     try:
-        enable_daemon = subprocess.Popen(['sudo', 'systemctl', 'enable' ,'protonvpn-autoconnect'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, enable_err = enable_daemon.communicate()
+        resp = subprocess.run(['sudo', 'systemctl', 'enable' , SERVICE_NAME], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        if resp.returncode == 1:
+            gui_logger.debug("[!] Unable to enable deamon.\n{}".format(resp))
+            return False
     except:
-        print("[!]Could not enable daemon.")
+        gui_logger.debug("[!] Could not run \"enable daemon\" subprocess.")
         return False
-
-    # Gives error since this throws message that a symlink is created, needs to be handled
-    # if not len(enable_err) == 0:
-    #     print("In enable_daemon (enable): ", enable_err)
-    #     return False
-
+    
     return True
     
 def stop_and_disable_daemon():
     """Stops the autoconnect service and disables it
     """
+    if not daemon_exists():
+        return True
+    else:
+        try:
+            resp_stop = subprocess.run(['sudo', 'systemctl', 'stop' , SERVICE_NAME], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            if resp_stop.returncode == 1:
+                gui_logger.debug("[!] Unable to stop deamon.\n{}".format(resp_stop))
+                return False
+        except:
+            gui_logger.debug("[!] Could not run \"stop daemon\" subprocess.")
+            return False
+
+        try:
+            resp_disable = subprocess.run(['sudo', 'systemctl', 'disable' ,SERVICE_NAME], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+            if resp_disable.returncode == 1:
+                gui_logger.debug("[!] Unable not disable daemon.\n{}".format(resp_disable))
+                return False
+        except:
+            gui_logger.debug("[!] Could not run \"disable daemon\" subprocess.")
+            return False
+
+        return True
+
+def reload_daemon():
     try:
-        stop_daemon = subprocess.Popen(['sudo', 'systemctl', 'stop' ,'protonvpn-autoconnect'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, stop_err = stop_daemon.communicate()
+        resp = subprocess.run(['sudo', 'systemctl', 'daemon-reload'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if resp.returncode == 1:
+            gui_logger.debug("[!] Unable to reload daemon.\n{}".format(resp))
+            return False
+        return True
     except:
-        print("[!]Could not stop deamon. Either not running or an error occurred.")
+        gui_logger.debug("[!] Could not run \"reload daemon\" subprocess.")
         return False
 
-    # Gives error if the service is not running
-    # if not len(stop_err) == 0:
-    #     print("In stop_and_disable_daemon (stop): ", stop_err)
-    #     return False
+def daemon_exists():
 
-    try:
-        disable_daemon = subprocess.Popen(['sudo', 'systemctl', 'disable' ,'protonvpn-autoconnect'],  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        _, disable_err = disable_daemon.communicate()
-    except:
-        print("[!]Could not disable daemon. Either it was already disabled or an error occurred.")
+    # Return code 3: service exists
+    # Return code 4: service could not be found
+    resp_stop = subprocess.run(['systemctl', 'status' , SERVICE_NAME], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # print(resp_stop)
+    if resp_stop.returncode == 4:
         return False
-
-    # Gives error if service is not enabled
-    # if not len(disable_err) == 0:
-    #     print("In stop_and_disable_daemon (disable): ", disable_err)
-    #     return False
-
-    return True
+    else:
+        return True
 
 def get_gui_processes():
 


### PR DESCRIPTION
**NEW FEATURE**

- Only works on **systemd** based OSs
- Auto-connect is now fully functional. Users can choose from within the configurations to which server they want to connect upon boot, such as:
  - Disabled
  - Fastest
  - Random
  - Peer2Peer
  - Secure Core (Plus/Visionary)
  - Tor (Plus/Visionary)
  - Countries:
    - Australia
    - Brazil
    - etc
- Code is based on Rafficers auto-connect <a href="https://github.com/ProtonVPN/protonvpn-cli-ng/blob/master/USAGE.md#auto-connect-on-boot">instructions</a>.

**UPDATE**
- Added some Q&A to the "help" button.
- Version Bumo