### PR TITLE
Issue fix and Pipfile update

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,3 @@ requests = "*"
 pycairo = "*"
 pygobject = "*"
 protonvpn-cli = "==2.2.2"
-
-[requires]
-python_version = "3.8"

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -2,7 +2,7 @@ try:
     from protonvpn_cli.constants import VERSION as cli_version
 except:
     cli_version = "Not installed"
-VERSION = "1.7.1"
+VERSION = "1.7.2"
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
 SERVICE_NAME = "custompvpn-autoconnect" 
 PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/{}.service".format(SERVICE_NAME)

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -535,7 +535,10 @@ def load_configurations(interface):
     populate_autoconnect_list(interface)
     autoconnect_combobox = interface.get_object("autoconnect_combobox")
 
-    autoconnect_setting = get_config_value("USER", "autoconnect")
+    try:
+        autoconnect_setting = get_config_value("USER", "autoconnect")
+    except KeyError:
+        autoconnect_setting = 0
 
     autoconnect_combobox.set_active(int(autoconnect_setting))
 


### PR DESCRIPTION
**ISSUE FIX**

- If a user initialized the profile via the CLI and the tried to open the Configurations window, a KeyError exception would be thrown since upon attempting to load autoconnect settings. This issue is mainly due to that the CLI does not implement autoconnect while the GUI does, thus throwing an error since the key "autoconnect" is not existent.
- Removed python_version from Pipfile since it should work on multiple python versions