### PR TITLE
Updated install instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ share/python-wheels/
 *.egg
 MANIFEST
 .vscode
+PKGBUILD
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Install `dbus-x11` package for your distribution, more information can be found 
 
 ## Installing ProtonVPN Linux GUI
 
+### Distribution based
+- Fedora: To-do
+- Ubuntu: To-do
+- OpenSUSE: To-do
+- Arch Linux: <a href="https://aur.archlinux.org/packages/protonvpn-linux-gui/" target="_blank">Available at AUR</a>
+
+
+### PIP based
 You can either install via <b>PIP</b> or by cloning the repository.
 
 *Note: Make sure to run pip with sudo*


### PR DESCRIPTION
- Users should be able to install the GUI via their distributions (and their derivations).
  - Fedora: To-do
  - Ubuntu: To-do
  - OpenSUSE: To-do
  - Arch: [Available at AUR](https://aur.archlinux.org/packages/protonvpn-linux-gui/)