### PR TITLE
Tray configurations update

### DIFF
--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -2,7 +2,7 @@ try:
     from protonvpn_cli.constants import VERSION as cli_version
 except:
     cli_version = "Not installed"
-VERSION = "1.8.0"
+VERSION = "1.8.1"
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
 SERVICE_NAME = "custompvpn-autoconnect" 
 PATH_AUTOCONNECT_SERVICE = "/etc/systemd/system/{}.service".format(SERVICE_NAME)

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -46,7 +46,8 @@ from .thread_functions import(
     purge_configurations,
     kill_duplicate_gui_process,
     load_content_on_start,
-    update_autoconnect
+    update_autoconnect,
+    tray_configurations
 )
 
 # Import version
@@ -489,6 +490,21 @@ class Handler:
         gui_logger.debug(">>> Starting \"update_split_tunneling\" thread.")
 
         thread = Thread(target=update_split_tunneling, args=[self.interface, self.messagedialog_label, self.messagedialog_spinner])
+        thread.daemon = True
+        thread.start()
+
+        self.messagedialog_window.show()    
+    
+    def update_tray_configurations_button_clicked(self, button):
+        """Button/Event handler to update Tray display configurations
+        """
+        self.messagedialog_sub_label.hide()
+        self.messagedialog_label.set_markup("Updating tray display configurations...")
+        self.messagedialog_spinner.show()
+
+        gui_logger.debug(">>> Starting \"tray_configurations\" thread.")
+
+        thread = Thread(target=tray_configurations, args=[self.interface, self.messagedialog_label, self.messagedialog_spinner])
         thread.daemon = True
         thread.start()
 

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -54,6 +54,553 @@
       </row>
     </data>
   </object>
+  <object class="GtkApplicationWindow" id="LoginWindow">
+    <property name="name">Main Window</property>
+    <property name="can_focus">True</property>
+    <property name="is_focus">True</property>
+    <property name="title" translatable="yes">ProtonVPN GUI - Login</property>
+    <property name="window_position">center-always</property>
+    <property name="default_width">440</property>
+    <property name="default_height">250</property>
+    <property name="icon">protonvpn_logo.png</property>
+    <property name="gravity">center</property>
+    <property name="has_resize_grip">True</property>
+    <property name="show_menubar">False</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkGrid">
+        <property name="width_request">100</property>
+        <property name="height_request">0</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
+        <property name="hexpand">True</property>
+        <property name="vexpand">True</property>
+        <property name="row_spacing">5</property>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">20</property>
+            <property name="margin_bottom">10</property>
+            <child>
+              <object class="GtkEntry" id="password_field">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
+                <property name="margin_left">10</property>
+                <property name="margin_right">10</property>
+                <property name="hexpand">True</property>
+                <property name="visibility">False</property>
+                <property name="has_frame">False</property>
+                <property name="invisible_char">*</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="label" translatable="yes">Password</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="12000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">20</property>
+            <property name="margin_bottom">10</property>
+            <child>
+              <object class="GtkEntry" id="username_field">
+                <property name="width_request">10</property>
+                <property name="height_request">0</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_focus">True</property>
+                <property name="margin_left">10</property>
+                <property name="margin_right">10</property>
+                <property name="hexpand">True</property>
+                <property name="has_frame">False</property>
+                <property name="max_width_chars">30</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">30</property>
+                <property name="margin_bottom">40</property>
+                <property name="pixbuf">protonvpn_logo_full.png</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="label" translatable="yes">Username</property>
+                <property name="justify">fill</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="12000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">30</property>
+                <property name="label" translatable="yes">Unofficial ProtonVPN Linux GUI </property>
+                <property name="justify">fill</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="15000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">20</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkButton" id="button">
+                <property name="label" translatable="yes">Initialize Profile</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">center</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="on_login_button_clicked" swapped="no"/>
+                <child internal-child="accessible">
+                  <object class="AtkObject" id="button-atkobject">
+                    <property name="AtkObject::accessible-role" translatable="yes">push-button</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child type="center">
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">20</property>
+            <property name="margin_bottom">10</property>
+            <property name="row_homogeneous">True</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="label" translatable="yes">ProtonVPN Plan</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="12000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="member_free">
+                <property name="label" translatable="yes">Free</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="member_basic">
+                <property name="label" translatable="yes">Basic</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">member_free</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="member_plus">
+                <property name="label" translatable="yes">Plus</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">member_free</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="member_visionary">
+                <property name="label" translatable="yes">Visionary</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">member_free</property>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="margin_top">20</property>
+            <property name="margin_bottom">10</property>
+            <property name="row_homogeneous">True</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkRadioButton" id="protocol_tcp_checkbox">
+                <property name="label" translatable="yes">TCP</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_right">15</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="protocol_udp_checkbox">
+                <property name="label" translatable="yes">UDP</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_left">15</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+                <property name="group">protocol_tcp_checkbox</property>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="label" translatable="yes">Default OpenVPN Protocol</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                  <attribute name="size" value="12000"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+                <property name="width">4</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkDialog" id="MessageDialog">
+    <property name="width_request">400</property>
+    <property name="height_request">200</property>
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">ProtonVPN GUI</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="window_position">center</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="icon">protonvpn_logo.png</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="skip_pager_hint">True</property>
+    <property name="gravity">center</property>
+    <signal name="delete-event" handler="MessageDialog_delete_event" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="is_focus">True</property>
+        <property name="margin_left">25</property>
+        <property name="margin_right">25</property>
+        <property name="margin_top">20</property>
+        <property name="margin_bottom">20</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkButton" id="message_dialog_close_button">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="close_message_dialog" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="message_dialog_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_top">30</property>
+            <property name="margin_bottom">30</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
+            <property name="width_chars">40</property>
+            <property name="max_width_chars">70</property>
+            <attributes>
+              <attribute name="size" value="12000"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="message_dialog_sub_label">
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_top">15</property>
+            <property name="margin_bottom">30</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
+            <property name="width_chars">40</property>
+            <property name="max_width_chars">70</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinner" id="message_dialog_spinner">
+            <property name="width_request">50</property>
+            <property name="height_request">50</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">center</property>
+            <property name="margin_bottom">50</property>
+            <property name="active">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+  <object class="GtkListStore" id="ServerListStore">
+    <columns>
+      <!-- column-name Country -->
+      <column type="gchararray"/>
+      <!-- column-name Server# -->
+      <column type="gchararray"/>
+      <!-- column-name Tier -->
+      <column type="gchararray"/>
+      <!-- column-name Load -->
+      <column type="gchararray"/>
+      <!-- column-name Feature -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkTreeStore" id="ServerTreeStore">
+    <columns>
+      <!-- column-name Country -->
+      <column type="gchararray"/>
+      <!-- column-name Server -->
+      <column type="gchararray"/>
+      <!-- column-name Tier -->
+      <column type="gchararray"/>
+      <!-- column-name Load -->
+      <column type="gchararray"/>
+      <!-- column-name Feature -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="Tray_Configurations">
+    <columns>
+      <!-- column-name ID -->
+      <column type="guint"/>
+      <!-- column-name Status -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0">0</col>
+        <col id="1" translatable="yes">Do not display</col>
+      </row>
+      <row>
+        <col id="0">1</col>
+        <col id="1" translatable="yes">Display</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkWindow" id="ConfigurationsWindow">
     <property name="width_request">680</property>
     <property name="height_request">720</property>
@@ -691,7 +1238,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">8</property>
+                    <property name="top_attach">7</property>
                   </packing>
                 </child>
                 <child>
@@ -794,7 +1341,7 @@
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">7</property>
+                    <property name="top_attach">6</property>
                   </packing>
                 </child>
                 <child>
@@ -898,543 +1445,186 @@
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
-                </child>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkApplicationWindow" id="LoginWindow">
-    <property name="name">Main Window</property>
-    <property name="can_focus">True</property>
-    <property name="is_focus">True</property>
-    <property name="title" translatable="yes">ProtonVPN GUI - Login</property>
-    <property name="window_position">center-always</property>
-    <property name="default_width">440</property>
-    <property name="default_height">250</property>
-    <property name="icon">protonvpn_logo.png</property>
-    <property name="gravity">center</property>
-    <property name="has_resize_grip">True</property>
-    <property name="show_menubar">False</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
-    <child>
-      <object class="GtkGrid">
-        <property name="width_request">100</property>
-        <property name="height_request">0</property>
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="halign">center</property>
-        <property name="valign">center</property>
-        <property name="margin_top">10</property>
-        <property name="margin_bottom">10</property>
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
-        <property name="row_spacing">5</property>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <child>
-              <object class="GtkEntry" id="password_field">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="hexpand">True</property>
-                <property name="visibility">False</property>
-                <property name="has_frame">False</property>
-                <property name="invisible_char">*</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">Password</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <child>
-              <object class="GtkEntry" id="username_field">
-                <property name="width_request">10</property>
-                <property name="height_request">0</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="hexpand">True</property>
-                <property name="has_frame">False</property>
-                <property name="max_width_chars">30</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">30</property>
-                <property name="margin_bottom">40</property>
-                <property name="pixbuf">protonvpn_logo_full.png</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">Username</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">30</property>
-                <property name="label" translatable="yes">Unofficial ProtonVPN Linux GUI </property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="15000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="orientation">vertical</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkButton" id="button">
-                <property name="label" translatable="yes">Initialize Profile</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="halign">center</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="always_show_image">True</property>
-                <signal name="clicked" handler="on_login_button_clicked" swapped="no"/>
-                <child internal-child="accessible">
-                  <object class="AtkObject" id="button-atkobject">
-                    <property name="AtkObject::accessible-role" translatable="yes">push-button</property>
+                  <object class="GtkGrid" id="purge_conf_grid1">
+                    <property name="width_request">477</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_bottom">40</property>
+                    <property name="row_spacing">15</property>
+                    <property name="column_spacing">15</property>
+                    <property name="column_homogeneous">True</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">Tray Configurations</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="size" value="12000"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
+                        <property name="width">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="update_tray_configurations_button">
+                        <property name="label" translatable="yes">Update Tray</property>
+                        <property name="width_request">150</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">center</property>
+                        <property name="margin_top">10</property>
+                        <signal name="clicked" handler="update_tray_configurations_button_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="tray_data_tx_combobox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="model">Tray_Configurations</property>
+                        <property name="active">0</property>
+                        <property name="has_frame">False</property>
+                        <property name="entry_text_column">1</property>
+                        <property name="id_column">0</property>
+                        <child>
+                          <object class="GtkCellRendererText"/>
+                          <attributes>
+                            <attribute name="text">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="tray_servername_combobox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="model">Tray_Configurations</property>
+                        <property name="active">0</property>
+                        <property name="has_frame">False</property>
+                        <property name="entry_text_column">1</property>
+                        <property name="id_column">0</property>
+                        <child>
+                          <object class="GtkCellRendererText"/>
+                          <attributes>
+                            <attribute name="text">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBox" id="tray_time_connected_combobox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="model">Tray_Configurations</property>
+                        <property name="active">0</property>
+                        <property name="has_frame">False</property>
+                        <property name="entry_text_column">1</property>
+                        <property name="id_column">0</property>
+                        <child>
+                          <object class="GtkCellRendererText"/>
+                          <attributes>
+                            <attribute name="text">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">4</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">Data Transmitted</property>
+                        <attributes>
+                          <attribute name="weight" value="medium"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">Servername</property>
+                        <attributes>
+                          <attribute name="weight" value="medium"/>
+                          <attribute name="size" value="12000"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">10</property>
+                        <property name="margin_bottom">10</property>
+                        <property name="label" translatable="yes">Time Connected</property>
+                        <attributes>
+                          <attribute name="weight" value="medium"/>
+                          <attribute name="size" value="12000"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">4</property>
+                        <property name="top_attach">1</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
                   </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">8</property>
+                  </packing>
                 </child>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child type="center">
-              <placeholder/>
             </child>
           </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <property name="row_homogeneous">True</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">ProtonVPN Plan</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-                <property name="width">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="member_free">
-                <property name="label" translatable="yes">Free</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="member_basic">
-                <property name="label" translatable="yes">Basic</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">member_free</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="member_plus">
-                <property name="label" translatable="yes">Plus</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">member_free</property>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="member_visionary">
-                <property name="label" translatable="yes">Visionary</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">member_free</property>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="halign">center</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <property name="row_homogeneous">True</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkRadioButton" id="protocol_tcp_checkbox">
-                <property name="label" translatable="yes">TCP</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="margin_right">15</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkRadioButton" id="protocol_udp_checkbox">
-                <property name="label" translatable="yes">UDP</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="margin_left">15</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-                <property name="group">protocol_tcp_checkbox</property>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">Default OpenVPN Protocol</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-                <property name="width">4</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">3</property>
-          </packing>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkDialog" id="MessageDialog">
-    <property name="width_request">400</property>
-    <property name="height_request">200</property>
-    <property name="can_focus">False</property>
-    <property name="title" translatable="yes">ProtonVPN GUI</property>
-    <property name="resizable">False</property>
-    <property name="modal">True</property>
-    <property name="window_position">center</property>
-    <property name="destroy_with_parent">True</property>
-    <property name="icon">protonvpn_logo.png</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="gravity">center</property>
-    <signal name="delete-event" handler="MessageDialog_delete_event" swapped="no"/>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
-    <child internal-child="vbox">
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="is_focus">True</property>
-        <property name="margin_left">25</property>
-        <property name="margin_right">25</property>
-        <property name="margin_top">20</property>
-        <property name="margin_bottom">20</property>
-        <property name="orientation">vertical</property>
-        <property name="spacing">2</property>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkButton" id="message_dialog_close_button">
-                <property name="label" translatable="yes">Close</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="always_show_image">True</property>
-                <signal name="clicked" handler="close_message_dialog" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="message_dialog_label">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <property name="margin_top">30</property>
-            <property name="margin_bottom">30</property>
-            <property name="wrap">True</property>
-            <property name="selectable">True</property>
-            <property name="width_chars">40</property>
-            <property name="max_width_chars">70</property>
-            <attributes>
-              <attribute name="size" value="12000"/>
-            </attributes>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="message_dialog_sub_label">
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <property name="margin_top">15</property>
-            <property name="margin_bottom">30</property>
-            <property name="wrap">True</property>
-            <property name="selectable">True</property>
-            <property name="width_chars">40</property>
-            <property name="max_width_chars">70</property>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinner" id="message_dialog_spinner">
-            <property name="width_request">50</property>
-            <property name="height_request">50</property>
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="valign">center</property>
-            <property name="margin_bottom">50</property>
-            <property name="active">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
-  <object class="GtkListStore" id="ServerListStore">
-    <columns>
-      <!-- column-name Country -->
-      <column type="gchararray"/>
-      <!-- column-name Server# -->
-      <column type="gchararray"/>
-      <!-- column-name Tier -->
-      <column type="gchararray"/>
-      <!-- column-name Load -->
-      <column type="gchararray"/>
-      <!-- column-name Feature -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
-  <object class="GtkTreeStore" id="ServerTreeStore">
-    <columns>
-      <!-- column-name Country -->
-      <column type="gchararray"/>
-      <!-- column-name Server -->
-      <column type="gchararray"/>
-      <!-- column-name Tier -->
-      <column type="gchararray"/>
-      <!-- column-name Load -->
-      <column type="gchararray"/>
-      <!-- column-name Feature -->
-      <column type="gchararray"/>
-    </columns>
   </object>
   <object class="GtkImage" id="gtk-execute">
     <property name="visible">True</property>

--- a/protonvpn_linux_gui/thread_functions.py
+++ b/protonvpn_linux_gui/thread_functions.py
@@ -21,7 +21,6 @@ from .utils import (
     populate_server_list,
     prepare_initilizer,
     load_on_start,
-    load_configurations,
     update_labels_server_list,
     get_gui_processes,
     manage_autoconnect,
@@ -603,6 +602,33 @@ def update_split_tunneling(interface, messagedialog_label, messagedialog_spinner
 
     gui_logger.debug(">>> Ended tasks in \"set_split_tunnel\" thread.")   
 
+def tray_configurations(interface, messagedialog_label, messagedialog_spinner):
+    """Function to update what the tray should display.
+    """    
+    gui_logger.debug(">>> Running \"tray_configurations\".")
+
+    tray_data_tx_combobox = interface.get_object("tray_data_tx_combobox").get_active()
+    tray_servername_combobox = interface.get_object("tray_servername_combobox").get_active()
+    tray_time_connected_combobox = interface.get_object("tray_time_connected_combobox").get_active()
+
+    set_config_value("USER", "display_server", tray_servername_combobox)
+    set_config_value("USER", "display_user_tx", tray_data_tx_combobox)
+    set_config_value("USER", "display_time_conn", tray_time_connected_combobox)
+
+    data_tx_msg = "Display" if tray_data_tx_combobox == 1 else "Do not display"
+    servername_msg = "Display" if tray_servername_combobox == 1 else "Do not display"
+    time_connected_msg = "Display" if tray_time_connected_combobox == 1 else "Do not display"
+
+    custom_msg = "Data Transmitted: {0}\nServername: {1}\nTime Connected: {2}".format(data_tx_msg, servername_msg, time_connected_msg)
+
+    result = "Tray configurations <b>updated</b>!\n\n" + custom_msg
+    messagedialog_label.set_markup(result)
+    messagedialog_spinner.hide()
+
+    gui_logger.debug(">>> Result: \"{0}\"".format(result))
+
+    gui_logger.debug(">>> Ended tasks in \"tray_configurations\" thread.")   
+    
 def purge_configurations(interface, messagedialog_label, messagedialog_spinner):
     """Function to purge all current configurations.
     """

--- a/protonvpn_linux_gui/tray_icon.py
+++ b/protonvpn_linux_gui/tray_icon.py
@@ -13,7 +13,8 @@ from gi.repository import AppIndicator3 as appindicator
 from protonvpn_cli.utils import (
     get_country_name,
     get_config_value,
-    is_connected
+    is_connected,
+    get_transferred_data
 )
 
 CURRDIR = os.path.dirname(os.path.abspath(__file__))
@@ -22,6 +23,7 @@ class ProtonVPNIndicator:
     def __init__(self):
         self.gtk = Gtk
         self.gobject = GObject
+        self.VARL = 0
         self.menu = self.menu()
         self.ind = appindicator.Indicator.new(
             "ProtonVPN GUI Indicator", 
@@ -35,40 +37,75 @@ class ProtonVPNIndicator:
         self.gtk.main()
 
     def menu(self):
-        menu = self.gtk.Menu()
-
-        q_connect = self.gtk.MenuItem(label='Quick Connect')
-        q_connect.connect('activate', self.quick_connect)
-        menu.append(q_connect)
-
-        disconn = self.gtk.MenuItem(label='Disconnect')
-        disconn.connect('activate', self.disconnect)
-        menu.append(disconn)
-
-        separator = self.gtk.SeparatorMenuItem()
-        menu.append(separator)
-
-        gui = self.gtk.MenuItem(label='Show GUI')
-        gui.connect('activate', self.show_gui)
-        menu.append(gui) 
+        self.menu = self.gtk.Menu()
         
-        separator = self.gtk.SeparatorMenuItem()
-        menu.append(separator)
+        self.data_sent = self.gtk.MenuItem(label='')
+        self.menu.append(self.data_sent)
 
-        exittray = self.gtk.MenuItem(label='Quit')
-        exittray.connect('activate', self.quit_indicator)
-        menu.append(exittray)
+        self.data_rec = self.gtk.MenuItem(label='')
+        self.menu.append(self.data_rec)
 
-        menu.show_all()
-        return menu
+        self.time_conn = self.gtk.MenuItem(label='')
+        self.menu.append(self.time_conn) 
+
+        self.ip = self.gtk.MenuItem(label='')
+        self.menu.append(self.ip)
+
+        self.separator_0 = self.gtk.SeparatorMenuItem()
+        self.menu.append(self.separator_0)
+        self.separator_0.show()
+
+        self.q_connect = self.gtk.MenuItem(label='Quick Connect')
+        self.q_connect.connect('activate', self.quick_connect)
+        self.menu.append(self.q_connect)
+        self.q_connect.show()
+
+        self.disconn = self.gtk.MenuItem(label='Disconnect')
+        self.disconn.connect('activate', self.disconnect)
+        self.menu.append(self.disconn)
+        self.disconn.show()
+
+        self.separator_1 = self.gtk.SeparatorMenuItem()
+        self.menu.append(self.separator_1)
+        self.separator_1.show()
+
+        self.gui = self.gtk.MenuItem(label='Show GUI')
+        self.gui.connect('activate', self.show_gui)
+        self.menu.append(self.gui) 
+        self.gui.show()
+        
+        self.separator_2 = self.gtk.SeparatorMenuItem()
+        self.menu.append(self.separator_2)
+        self.separator_2.show()
+
+        self.exittray = self.gtk.MenuItem(label='Quit')
+        self.exittray.connect('activate', self.quit_indicator)
+        self.menu.append(self.exittray)
+        self.exittray.show()
+
+        return self.menu
 
     def connection_status(self, _):
         icon_path = "/resources/protonvpn_logo_alt.png"
-        
+        display_data_rec = False
+        display_server = False
+        display_time_conn = False
+
         if is_connected():
             icon_path = "/resources/protonvpn_logo.png"
-            
+            settings = self.get_tray_settings()
+
+            display_data_rec = True if settings["display_data_tx"] else False
+            display_server = True if settings["display_server"] else False
+            display_time_conn = True if settings["display_time_conn"] else False
+
+        self.display_extra_info(
+                                display_data_rec=display_data_rec,
+                                display_server=display_server, 
+                                display_time_conn=display_time_conn)
+
         self.ind.set_icon_full(CURRDIR + icon_path, 'protonvpn')
+
         return True
   
     def quick_connect(self, _):
@@ -80,21 +117,82 @@ class ProtonVPNIndicator:
     def disconnect(self, _):
         subprocess.Popen(["sudo", "protonvpn", "disconnect"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    def update_label(self, _):
-        if is_connected():  
-            try:
-                connected_time = get_config_value("metadata", "connected_time")
-                connection_time = time.time() - int(connected_time)
-                connection_time = str(datetime.timedelta(seconds=connection_time)).split(".")[0]
-            except KeyError:
-                connection_time = False
-        
-            connection_time = connection_time if connection_time else ""
-        else:
-            connection_time = "N/A"
+    def get_tray_settings(self):
 
-        self.ind.set_label(connection_time, "")
-        return True
+        resp_dict = {
+            "display_data_tx": False,
+            "display_server": False,
+            "display_time_conn": False,
+        }
+
+        try: 
+            resp_dict["display_server"] = int(get_config_value("USER", "display_server"))
+        except KeyError:
+            pass
+
+        try: 
+            resp_dict["display_data_tx"] = int(get_config_value("USER", "display_user_tx"))
+        except KeyError:
+            pass 
+        
+        try: 
+            resp_dict["display_time_conn"] = int(get_config_value("USER", "display_time_conn"))
+        except KeyError:
+            pass
+
+        return resp_dict
+
+    def display_extra_info(self, **kwrgs):
+
+        if kwrgs["display_server"]: 
+            server = get_config_value("metadata", "connected_server")
+            self.ind.set_label(server, "")
+        else:
+            self.ind.set_label("", "")
+
+        if kwrgs["display_data_rec"]:
+            received, sent = self.data_sent_received()
+
+            display_data_rec = "Received: {}".format(received)
+            display_data_sent = "Sent: {}".format(sent)
+
+            self.data_rec.get_child().set_text(display_data_rec)
+            self.data_sent.get_child().set_text(display_data_sent)
+
+            self.data_rec.show()
+            self.data_sent.show()
+        else: 
+            self.data_rec.hide()
+            self.data_sent.hide()
+
+        if kwrgs["display_time_conn"]:
+            display_time_conn = self.time_connected()
+
+            self.time_conn.get_child().set_text("Connection time: {}".format(display_time_conn))
+
+            self.time_conn.show()
+        else: 
+            self.time_conn.hide()
+
+    def data_sent_received(self):
+        sent_amount, received_amount = get_transferred_data()
+
+        sent_amount = sent_amount if is_connected else ""
+        received_amount = received_amount if is_connected else ""
+
+        return (received_amount, sent_amount)
+
+    def time_connected(self):
+        try:
+            connected_time = get_config_value("metadata", "connected_time")
+            connection_time = time.time() - int(connected_time)
+            connection_time = str(datetime.timedelta(seconds=connection_time)).split(".")[0]
+        except KeyError:
+            connection_time = False
+    
+        connection_time = connection_time if connection_time else ""
+
+        return connection_time
 
     def quit_indicator(self, _):
         self.gtk.main_quit()

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -586,6 +586,32 @@ def load_configurations(interface):
     except FileNotFoundError:
         split_tunneling_buffer.set_text(content)
 
+    # Load tray configurations
+    display_server = 0
+    display_data_tx = 0
+    display_time_conn = 0
+
+    try: 
+        display_data_tx = int(get_config_value("USER", "display_user_tx"))
+    except KeyError:
+        gui_logger.debug("[!] Unable to find display_data_tx key.")
+    try: 
+        display_server = int(get_config_value("USER", "display_server"))
+    except KeyError:
+        gui_logger.debug("[!] Unable to find display_server key.")
+    try: 
+        display_time_conn = int(get_config_value("USER", "display_time_conn"))
+    except KeyError:
+        gui_logger.debug("[!] Unable to find display_time_conn key.")
+
+    tray_data_tx_combobox = interface.get_object("tray_data_tx_combobox")
+    tray_servername_combobox = interface.get_object("tray_servername_combobox")
+    tray_time_connected_combobox = interface.get_object("tray_time_connected_combobox")
+
+    tray_data_tx_combobox.set_active(display_data_tx)
+    tray_servername_combobox.set_active(display_server)
+    tray_time_connected_combobox.set_active(display_time_conn)
+
     pref_dialog.show()
 
 def populate_server_list(populate_servers_dict):


### PR DESCRIPTION
**UPDATE**
- Users can now update which type of information that the tray icon should display.
- Tray display configurations are managed from within the GUI, in the Configurations window.
- At the moment, users can:
  - Display server name
  - Display connection time (how long a user has been connected)
  - Display the amount of sent and received data