### PR TITLE
Split tunneling logic update; GUI polish

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,8 +6,8 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-requests = "==2.23.0"
+requests = ">=2.23.0"
 pycairo = "*"
 pygobject = "*"
 protonvpn-cli = "==2.2.2"
-configparser = "==4.0.2"
+configparser = ">=4.0.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1937a0e30719c92a5f2ec9dad6e2ea5e2f4525cf426f5ce9e98b8e5486462419"
+            "sha256": "6da4608cd054f63434b3374bc5e15bee815983614b2c66ad625fe800cfb93ac5"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -30,11 +30,11 @@
         },
         "configparser": {
             "hashes": [
-                "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c",
-                "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"
+                "sha256:2ca44140ee259b5e3d8aaf47c79c36a7ab0d5e94d70bd4105c03ede7a20ea5a1",
+                "sha256:cffc044844040c7ce04e9acd1838b5f2e5fa3170182f6fda4d2ea8b0099dbadd"
             ],
             "index": "pypi",
-            "version": "==4.0.2"
+            "version": "==5.0.0"
         },
         "docopt": {
             "hashes": [
@@ -87,10 +87,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
-                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
-            "version": "==1.25.8"
+            "version": "==1.25.9"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Protonvpn-linux-gui works on top of <a href="https://github.com/ProtonVPN/proton
 
 #### Python dependencies
 - python >= 3.5
-- requests == 2.23.0
-- configparse == 4.0.2
+- requests >= 2.23.0
+- configparse >= 4.0.2
 - pip for python3 (pip3)
 - <a href="https://github.com/ProtonVPN/protonvpn-cli-ng"><b>protonvpn-cli-ng</b></a> == 2.2.2
 - setuptools for python3 (python3-setuptools)

--- a/protonvpn_linux_gui/constants.py
+++ b/protonvpn_linux_gui/constants.py
@@ -5,7 +5,7 @@ except:
     cli_version = "Not installed"
     USER = '/home'
 
-VERSION = "2.0.4"
+VERSION = "2.0.5"
 
 GITHUB_URL_RELEASE = "https://github.com/calexandru2018/protonvpn-linux-gui/releases/latest"
 

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -662,7 +662,11 @@ class Handler:
 
     def split_tunneling_switch_changed(self, object, state):
         split_tunnel_grid = self.interface.get_object("split_tunneling_grid") 
-        split_tunnel = get_config_value("USER", "split_tunnel")
+        try:
+            split_tunnel = get_config_value("USER", "split_tunnel")
+        except KeyError:
+            gui_logger.debug("[!] Split tunneling has not been configured.")
+            split_tunnel = 0
         
         if split_tunnel == "0":
             update_to = "1"
@@ -672,7 +676,6 @@ class Handler:
         if state:
             split_tunnel_grid.show()
         else:
-
             split_tunnel_grid.hide()
 
         if (state and split_tunnel == "0") or (not state and split_tunnel != "0"):

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -742,6 +742,10 @@ class Handler:
         self.messagedialog_label.set_markup("This feature is not yet implemented.")
         self.messagedialog_window.show()
 
+    def need_help_link_activate(self, object, link):
+        popover = self.interface.get_object("login_window_popover")
+        popover.show()
+
 def initialize_gui():
     """Initializes the GUI 
     ---

--- a/protonvpn_linux_gui/gui.py
+++ b/protonvpn_linux_gui/gui.py
@@ -850,6 +850,8 @@ def initialize_gui():
         if not os.path.isfile(CONFIG_FILE):   
             gui_logger.debug(">>> Loading LoginWindow")
             window = interface.get_object("LoginWindow")
+            version_label = interface.get_object("login_window_version_label")
+            version_label.set_markup("v.{}".format(VERSION))
             dashboard = interface.get_object("DashboardWindow")
             dashboard.connect("destroy", Gtk.main_quit)
         else:

--- a/protonvpn_linux_gui/resources/main.css
+++ b/protonvpn_linux_gui/resources/main.css
@@ -10,8 +10,6 @@ label selection{
     background-color: @def_green_color;
 }
 
-
-
 .default_background{
     background-color: @def_bg_color;
     color: rgb(255,255,255);;
@@ -30,6 +28,7 @@ label selection{
 }
 
 .menu_bar menuitem window menu{
+    border-radius: 0;
     box-shadow: none;
     border:none;
     color: rgb(255,255,255);
@@ -260,7 +259,14 @@ notebook.dashboard_notebook_style tabs tab{
 }
 
 .default_style_combobox window menu{
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
     background-color: @def_bg_color;
+	color:rgb(255,255,255);;
+}
+
+.default_style_combobox window menu menuitem cellview{
 	color:rgb(255,255,255);;
 }
 

--- a/protonvpn_linux_gui/resources/main.css
+++ b/protonvpn_linux_gui/resources/main.css
@@ -2,18 +2,37 @@
 @define-color overlay_color rgba(52, 58, 63, 1);
 @define-color def_green_color rgb(86, 179, 102);
 
+label, entry{
+    text-shadow: none;
+}
+
 label selection{
     background-color: @def_green_color;
 }
 
+
+
 .default_background{
     background-color: @def_bg_color;
-    color: white;
+    color: rgb(255,255,255);;
 }
 
 .overlay_background{
     background-color: @overlay_color;
-    color: white;
+    color: rgb(255,255,255);;
+}
+
+.menu_bar{
+    border: none;
+    box-shadow: none;
+    background-color: @overlay_color;
+    color: rgb(255,255,255);
+}
+
+.menu_bar menuitem window menu{
+    box-shadow: none;
+    border:none;
+    color: rgb(255,255,255);
 }
 
 .top_menu_hamburger{
@@ -26,7 +45,7 @@ label selection{
 }
 
 .white_text{
-    color: white;
+    color: rgb(255,255,255);;
 }
 
 .default_style_switch{
@@ -51,9 +70,9 @@ label selection{
     background-image: none;
     text-shadow: none;
     background-color: @def_bg_color;
-    color: white;
+    color: rgb(255,255,255);;
     padding: 10px 50px;
-    border: 2px solid white;
+    border: 2px solid rgb(255,255,255);;
     border-radius: 20px;
     transition: all .115s ease-in-out;
 }
@@ -65,9 +84,9 @@ label selection{
     box-shadow: none;
     background-image: none;
     text-shadow: none;
-    color: white;
+    color: rgb(255,255,255);;
     background-color: transparent;
-    border: 2px solid white;
+    border: 2px solid rgb(255,255,255);;
     padding: 10px 50px;
     border-radius: 20px;
     transition: all .115s ease-in-out;
@@ -80,7 +99,7 @@ label selection{
     box-shadow: none;
     background-image: none;
     text-shadow: none;
-    color: white;
+    color: rgb(255,255,255);;
     background-color: transparent;
     border: none;
     border-radius: 5px;
@@ -105,21 +124,27 @@ notebook.dashboard_notebook_style{
 }
 
 notebook.dashboard_notebook_style header{
+	-gtk-icon-source: none;
+    background-image: none;
 	outline:none;
 	padding: 0;
-    -gtk-icon-source: none;
     background-color: @overlay_color;
     border: none;
 }
 
 notebook.dashboard_notebook_style tabs{
+    -gtk-icon-source: none;
+    background-image: none;
 	outline:none;
 	padding: 0;
     margin: 0;
     border-bottom: 1px solid rgba(255,255,255, 0.3);
     border: none;
 }
-notebook.dashboard_notebook_style tab{
+
+notebook.dashboard_notebook_style tabs tab{
+	-gtk-icon-source: none;
+    background-image: none;
     outline:none;
     border-color: transparent;
     box-shadow: none;
@@ -134,7 +159,7 @@ notebook.dashboard_notebook_style tab{
     border: none;
     box-shadow: none;
     padding: 20px 70px;
-    color: white;
+    color: rgb(255,255,255);;
     transition: all .115s ease-in-out;
 }
 
@@ -150,7 +175,7 @@ notebook.dashboard_notebook_style tab{
 /* Dashboard notebook style*/
 
 .active_tab{
-    color: white;
+    color: rgb(255,255,255);;
     background-color: @def_bg_color;
 }
 
@@ -216,13 +241,17 @@ notebook.dashboard_notebook_style tab{
     outline: none;
     border-image-width: 0;
     background-color: @def_bg_color;
-    color: white;
+    color: rgb(255,255,255);;
     border-radius: 0;
     border: none;
 }
 
 .default_style_combobox button box arrow{
-    color: white;
+    color: rgb(255,255,255);;
+}
+
+.default_style_combobox button box cellview{
+    color: rgb(255,255,255);
 }
 
 .default_style_combobox button:focus{
@@ -232,7 +261,7 @@ notebook.dashboard_notebook_style tab{
 
 .default_style_combobox window menu{
     background-color: @def_bg_color;
-	color:white;
+	color:rgb(255,255,255);;
 }
 
 .server_list_bakground_row:hover, .menu_list_hover:hover, .default_style_combobox window menu menuitem:hover{
@@ -253,7 +282,7 @@ entry.default_style_entry{
     outline: none;
     box-shadow: none;
     background-color: @def_bg_color;
-    color: white;
+    color: rgb(255,255,255);;
     border-top: none;
     border-left: none;
     border-right: none;
@@ -291,9 +320,9 @@ notebook.settings_notebook_style{
 }
 
 notebook.settings_notebook_style header{
+    -gtk-icon-source: none;
 	outline:none;
 	padding: 0;
-    -gtk-icon-source: none;
     background-color: transparent;
     border: none;
 }
@@ -304,6 +333,9 @@ notebook.settings_notebook_style tabs{
 	margin: 0;
 }
 notebook.settings_notebook_style tab{
+    box-shadow: none;
+    border: transparent;
+    background-image: none;
 	outline:none;
 	padding: 0;
     margin: 0;
@@ -311,7 +343,7 @@ notebook.settings_notebook_style tab{
 }
 
 .default_notebook_grid_content{
-    color: white;
+    color: rgb(255,255,255);;
     background-color: @def_bg_color;
     padding: 30px 100px;
     padding-bottom: 200px;
@@ -324,12 +356,12 @@ notebook.settings_notebook_style tab{
 
 .split_tunnling_list{
     background-color: @overlay_color;
-    color: white;
+    color: rgb(255,255,255);;
     padding: 10px 10px;
     /* border-radius: 5px; */
 }
 .split_tunnling_list text{
     background-color: @overlay_color;
-    color: white;
+    color: rgb(255,255,255);;
     /* border-radius: 5px; */
 }

--- a/protonvpn_linux_gui/resources/main.css
+++ b/protonvpn_linux_gui/resources/main.css
@@ -2,6 +2,13 @@
 @define-color overlay_color rgba(52, 58, 63, 1);
 @define-color def_green_color rgb(86, 179, 102);
 
+.login_links link{
+    color: @def_green_color;
+}
+.login_links link:hover{
+    color: rgb(255,255,255);
+}
+
 label, entry{
     text-shadow: none;
 }

--- a/protonvpn_linux_gui/resources/main.css
+++ b/protonvpn_linux_gui/resources/main.css
@@ -5,8 +5,13 @@
 .login_links link{
     color: @def_green_color;
 }
+
 .login_links link:hover{
     color: rgb(255,255,255);
+}
+
+.login_version_label{
+    color: rgb(127,127,127);
 }
 
 label, entry{

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -551,6 +551,9 @@ Author: Alexandru Cheltuitor
             <property name="can_focus">False</property>
             <property name="halign">end</property>
             <property name="label" translatable="yes">v.2.0.5</property>
+            <style>
+              <class name="login_version_label"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">0</property>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -2775,8 +2775,7 @@ Author: Alexandru Cheltuitor
                       </object>
                     </child>
                     <style>
-                      <class name="overlay_background"/>
-                      <class name="remove_borders"/>
+                      <class name="menu_bar"/>
                     </style>
                   </object>
                   <packing>

--- a/protonvpn_linux_gui/resources/main.glade
+++ b/protonvpn_linux_gui/resources/main.glade
@@ -244,8 +244,8 @@ Author: Alexandru Cheltuitor
         <property name="can_focus">False</property>
         <property name="halign">center</property>
         <property name="valign">center</property>
-        <property name="margin_left">50</property>
-        <property name="margin_right">50</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
         <property name="margin_top">10</property>
         <property name="margin_bottom">10</property>
         <property name="hexpand">True</property>
@@ -262,8 +262,8 @@ Author: Alexandru Cheltuitor
               <object class="GtkImage">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_top">30</property>
-                <property name="margin_bottom">40</property>
+                <property name="margin_top">40</property>
+                <property name="margin_bottom">50</property>
                 <property name="pixbuf">img/logo/protonvpn-logo-white.png</property>
               </object>
               <packing>
@@ -302,51 +302,8 @@ Author: Alexandru Cheltuitor
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <property name="row_homogeneous">True</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="label" translatable="yes">Start on Boot</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch">
-                <property name="width_request">50</property>
-                <property name="can_focus">True</property>
-                <property name="halign">end</property>
-              </object>
-              <packing>
-                <property name="left_attach">3</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="margin_left">40</property>
+            <property name="margin_right">40</property>
             <property name="margin_top">30</property>
             <property name="margin_bottom">20</property>
             <property name="row_homogeneous">True</property>
@@ -451,47 +408,42 @@ Author: Alexandru Cheltuitor
           </packing>
         </child>
         <child>
-          <object class="GtkGrid">
+          <object class="GtkEntry" id="username_field">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">20</property>
-            <property name="margin_bottom">10</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">ProtonVPN (OpenVPN/IKEv2) Password</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="password_field">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="visibility">False</property>
-                <property name="has_frame">False</property>
-                <property name="invisible_char">*</property>
-                <style>
-                  <class name="default_style_entry"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
+            <property name="can_focus">True</property>
+            <property name="has_focus">True</property>
+            <property name="margin_left">40</property>
+            <property name="margin_right">40</property>
+            <property name="margin_bottom">30</property>
+            <property name="hexpand">True</property>
+            <property name="has_frame">False</property>
+            <property name="invisible_char">*</property>
+            <property name="placeholder_text" translatable="yes">ProtonVPN (OpenVPN/IKEv2) Username</property>
+            <style>
+              <class name="default_style_entry"/>
+            </style>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="password_field">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="has_focus">True</property>
+            <property name="margin_left">40</property>
+            <property name="margin_right">40</property>
+            <property name="margin_bottom">20</property>
+            <property name="hexpand">True</property>
+            <property name="visibility">False</property>
+            <property name="has_frame">False</property>
+            <property name="invisible_char">*</property>
+            <property name="placeholder_text" translatable="yes">ProtonVPN (OpenVPN/IKEv2) Password</property>
+            <style>
+              <class name="default_style_entry"/>
+            </style>
           </object>
           <packing>
             <property name="left_attach">0</property>
@@ -502,65 +454,17 @@ Author: Alexandru Cheltuitor
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="label" translatable="yes">ProtonVPN (OpenVPN/IKEv2) Username</property>
-                <property name="justify">fill</property>
-                <attributes>
-                  <attribute name="weight" value="bold"/>
-                  <attribute name="size" value="12000"/>
-                </attributes>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-                <property name="width">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkEntry" id="username_field">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="has_focus">True</property>
-                <property name="hexpand">True</property>
-                <property name="has_frame">False</property>
-                <property name="invisible_char">*</property>
-                <style>
-                  <class name="default_style_entry"/>
-                </style>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-                <property name="width">3</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="left_attach">0</property>
-            <property name="top_attach">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkGrid">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
             <property name="halign">center</property>
-            <property name="margin_top">50</property>
-            <property name="margin_bottom">30</property>
+            <property name="margin_left">40</property>
+            <property name="margin_right">40</property>
+            <property name="margin_top">40</property>
+            <property name="margin_bottom">40</property>
             <child>
               <object class="GtkButton" id="button">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="halign">center</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
                 <property name="always_show_image">True</property>
                 <signal name="clicked" handler="on_login_button_clicked" swapped="no"/>
                 <child>
@@ -593,7 +497,64 @@ Author: Alexandru Cheltuitor
           </object>
           <packing>
             <property name="left_attach">0</property>
+            <property name="top_attach">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">10</property>
+            <property name="column_homogeneous">True</property>
+            <child>
+              <object class="GtkLabel" id="need_help_link">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;a href="#"&gt;Need Help?&lt;/a&gt;</property>
+                <property name="use_markup">True</property>
+                <signal name="activate-link" handler="need_help_link_activate" swapped="no"/>
+                <style>
+                  <class name="login_links"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="create_account_link_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">&lt;a href="https://account.protonvpn.com/signup"&gt;Create Account&lt;/a&gt;</property>
+                <property name="use_markup">True</property>
+                <property name="track_visited_links">False</property>
+                <style>
+                  <class name="login_links"/>
+                </style>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
             <property name="top_attach">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="login_window_version_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">end</property>
+            <property name="label" translatable="yes">v.2.0.5</property>
+          </object>
+          <packing>
+            <property name="left_attach">0</property>
+            <property name="top_attach">6</property>
           </packing>
         </child>
         <style>
@@ -603,6 +564,63 @@ Author: Alexandru Cheltuitor
     </child>
     <style>
       <class name="default_background"/>
+    </style>
+  </object>
+  <object class="GtkPopoverMenu" id="login_window_popover">
+    <property name="can_focus">False</property>
+    <property name="relative_to">need_help_link</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">15</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">&lt;a href="https://account.protonvpn.com/reset-password"&gt;Reset Password&lt;/a&gt;</property>
+            <property name="use_markup">True</property>
+            <style>
+              <class name="login_links"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">&lt;a href="https://account.protonvpn.com/forgot-username"&gt;Forgot Username&lt;/a&gt;</property>
+            <property name="use_markup">True</property>
+            <style>
+              <class name="login_links"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="submenu">submenu1</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="overlay_background"/>
     </style>
   </object>
   <object class="GtkDialog" id="MessageDialog">

--- a/protonvpn_linux_gui/utils.py
+++ b/protonvpn_linux_gui/utils.py
@@ -609,12 +609,11 @@ def load_advanced_settings(interface):
     dns_leak_protection = get_config_value("USER", "dns_leak_protection")
     custom_dns = get_config_value("USER", "custom_dns")
     killswitch = get_config_value("USER", "killswitch")
-    split_tunnel = 0
 
     try:
         split_tunnel = get_config_value("USER", "split_tunnel")
     except KeyError:
-        pass
+        split_tunnel = '0'
 
     # Object
     dns_leak_switch = interface.get_object("update_dns_leak_switch")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Call with pip install -r requirements.txt
-requests==2.23.0
+requests>=2.23.0
 protonvpn-cli==2.2.2
-configparser==4.0.2
+configparser>=4.0.2
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     description="Unofficial Linux GUI client for ProtonVPN",
     long_description=long_descr,
     author="calexandru2018",
-    EMAIL="acrandom@pm.me"
+    EMAIL="acrandom@pm.me",
     license="GPLv3",
     url="https://github.com/calexandru2018/protonvpn-linux-gui",
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ setup(
     license="GPLv3",
     url="https://github.com/calexandru2018/protonvpn-linux-gui",
     install_requires=[
-        "protonvpn-cli==2.2.2",
+        "protonvpn-cli>=2.2.2",
         "requests==2.23.0",
-        "configparser==4.0.2"
+        "configparser>=4.0.2"
     ],
     python_requires=">=3.5",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,12 @@
 """setup.py: setuptools control."""
-
-
 import re
+import os
 from setuptools import setup
 
 from protonvpn_linux_gui.constants import VERSION
 
-
 try:
-    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+    with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'), encoding='utf-8') as f:
         long_descr = '\n' + f.read()
 except FileNotFoundError:
     long_descr = """

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,19 @@ from setuptools import setup
 from protonvpn_linux_gui.constants import VERSION
 
 
-long_descr = """
-The Unofficial Linux GUI for ProtonVPN.
+try:
+    with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
+        long_descr = '\n' + f.read()
+except FileNotFoundError:
+    long_descr = """
+    The Unofficial Linux GUI for ProtonVPN.
 
-For further information and a usage guide, please view the project page:
+    For further information and a usage guide, please view the project page:
 
-https://github.com/calexandru2018/protonvpn-linux-gui
-"""
+    https://github.com/calexandru2018/protonvpn-linux-gui
+    """
+
+
 
 setup(
     name="protonvpn-linux-gui-calexandru2018",
@@ -37,11 +43,12 @@ setup(
     description="Unofficial Linux GUI client for ProtonVPN",
     long_description=long_descr,
     author="calexandru2018",
+    EMAIL="acrandom@pm.me"
     license="GPLv3",
     url="https://github.com/calexandru2018/protonvpn-linux-gui",
     install_requires=[
         "protonvpn-cli>=2.2.2",
-        "requests==2.23.0",
+        "requests>=2.23.0",
         "configparser>=4.0.2"
     ],
     python_requires=">=3.5",


### PR DESCRIPTION
**LOGIC**
- Split tunneling would not load correctly if key was non-existent in the CLI configurations, this was now fixed.

**GUI**
- GUI had some weird artifacts on other distributions, such as text-shadows and box-shadows etc. These have now been fixed and the UI should look exactly the same.
- Login window has been updated so that it looks similarly to the original ProtonVPN login window.